### PR TITLE
fix syntax error bug on option parser in rest/index.py

### DIFF
--- a/rest/index.py
+++ b/rest/index.py
@@ -176,7 +176,7 @@ def initConfig():
     options.esport=getConfig('esport',9200,options.configfile)
     
 if __name__ == "__main__":
-    qparser=OptionParser()
+    parser=OptionParser()
     parser.add_option("-c", dest='configfile' , default='index.conf', help="configuration file to use")
     (options,args) = parser.parse_args()
     initConfig()


### PR DESCRIPTION
the qparser is not used, I think it should be parser since parser is not defined but used.
