### PR TITLE
11 Spaces indentation corrected so its 12 spaces. And removed unused variable.

### DIFF
--- a/lib/mozdef.py
+++ b/lib/mozdef.py
@@ -123,11 +123,11 @@ class MozDefMsg():
             raise MozDefError('Summary is a required field')
 
         if self.debug:
-           print(json.dumps(log_msg, sort_keys=True, indent=4))
-           return
+            print(json.dumps(log_msg, sort_keys=True, indent=4))
+            return
 
         try:
-            r = self.httpsession.post(self.mozdef_hostname, json.dumps(log_msg, sort_keys=True, indent=4), verify=self.verify_certificate, background_callback=self.httpsession_cb)
+            self.httpsession.post(self.mozdef_hostname, json.dumps(log_msg, sort_keys=True, indent=4), verify=self.verify_certificate, background_callback=self.httpsession_cb)
         except Exception as e:
             if not self.fire_and_forget_mode:
                 raise e


### PR DESCRIPTION
MozDef is only partly running on my Ubuntu machine, and I’m not Entirely sure on how to use it. 
Though these changes seemed simple enough and things looked OK when I tested with the changes .

To install python dependencies in a debian based system I changed the command to
sudo apt-get install make zlib1g-dev libbz2-dev libssl-dev libncurses5-dev libsqlite3-dev libreadline-dev tk-dev libpcre3-dev libpcre++-dev build-essential g++
