### PR TITLE
Workaround the epoll_wait(timeout..) cpu usage

### DIFF
--- a/lib/cefFifo2MQ.py
+++ b/lib/cefFifo2MQ.py
@@ -143,7 +143,7 @@ def postLogs(logcache):
         try:
             #see if we have anything to post
             #waiting a bit to not end until we are told we can stop.
-            postdata=logcache.get(False,30)
+            postdata=logcache.get(True,1)
             if postdata is None:
                 #signalled from parent process that it's ok to stop.
                 logcache.task_done()
@@ -292,7 +292,7 @@ def main():
                             bufa.append(buf)
                     else:
                         #non read event occurred, wait a bit and poll again.
-                        time.sleep(.001)
+                        time.sleep(.01)
                       
                                   
                 if '\n' in ''.join(bufa):


### PR DESCRIPTION
Increase sleep in the fifo polling a bit (saves a few % cpu)
Change the worker process queue to block on get and timeout quickly after 1s
This makes the script use about 0%cpu while idle instead of 100%
