### PR TITLE
Closes #81

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -172,7 +172,7 @@ Meteor
 
 We first need to install `Mongodb`_ since it's the DB used by Meteor.
 
-On Yum-based systems::
+On Yum-based systems:
 
 In /etc/yum.repo.d/mongo, add::
 


### PR DESCRIPTION
Closes #81 

Tested on Ubuntu 14.04 
Does this make the instruction to complicated? Should apt-get based instructions be in its own slide or in a gist?
