### PR TITLE
Missing a ">" at the end of the nxlog.conf file

### DIFF
--- a/examples/nxlog-syslog/nxlog.conf
+++ b/examples/nxlog-syslog/nxlog.conf
@@ -20,4 +20,4 @@ PidFile    "nxlog.pid"
 
 <Route httpout>
     Path    in => buffer=>outes,outfile
-</Route
+</Route>


### PR DESCRIPTION
In the configuration file for the nxlog-syslog, there's a missing ">" at the end of the file.
