### PR TITLE
Adding updated uwsgi ini config file for mozdefalertplugins init script.

### DIFF
--- a/alerts/alertPluginsmules.ini
+++ b/alerts/alertPluginsmules.ini
@@ -1,0 +1,16 @@
+[uwsgi]
+chdir = /home/mozdef/envs/mozdef/alerts/
+uid = mozdef
+mule = alertWorker.py
+pyargv = -c /home/mozdef/envs/mozdef/alerts/alertWorker.conf
+daemonize = /home/mozdef/envs/mozdef/logs/uwsgi.alertPluginsmules.log
+;ignore normal operations that generate nothing but normal response
+log-drain = generated 0 bytes
+log-date = %%a %%b %%d %%H:%%M:%%S
+socket = /home/mozdef/envs/mozdef/alerts/alertPluginsmules.socket
+virtualenv = /home/mozdef/envs/mozdef/
+master-fifo = /home/mozdef/envs/mozdef/alerts/alertPluginsmules.fifo
+never-swap
+pidfile= /home/mozdef/envs/mozdef/alerts/alertPluginsmules.pid
+vacuum = true
+enable-threads


### PR DESCRIPTION
Had to modify some things with this, the uwsgi- seemed to cause problems with the pid and fifo.
I've modified naming conventions to be more inline with the mq based uwsgi files.
lowercase initial letter, second word capitalized, and mules is lowercase: alertPluginsmules.ini

I also removed the 5 mule processes and enabled-threads instead. Allowing the fifo to control the processes is better than trying to capture the pid of every process that spawns.