### PR TITLE
Remove cloudtrail logic which hard codes the S3 bucket name

### DIFF
--- a/cron/cloudtrail2mozdef.py
+++ b/cron/cloudtrail2mozdef.py
@@ -31,9 +31,6 @@ from dateutil.parser import parse
 from datetime import date
 import pytz
 
-# This hack is in place while we wait for https://bugzilla.mozilla.org/show_bug.cgi?id=1216784 to be resolved
-HACK=True
-
 logger = logging.getLogger(sys.argv[0])
 
 class RoleManager:
@@ -274,13 +271,6 @@ def main():
                     ct = boto.cloudtrail.connect_to_region(region, 
                                                            **ct_credentials)
                     trails=ct.describe_trails()['trailList']
-                except boto.exception.NoAuthHandlerFound as e:
-                    # TODO Remove this hack once https://bugzilla.mozilla.org/show_bug.cgi?id=1216784 is complete
-                    if HACK:
-                        # logger.error("Working around missing permissions with a HACK")
-                        trails=[{'S3BucketName':'mozilla-cloudtrail-logs'}]
-                    else:
-                        continue
                 except Exception as e:
                     logger.error("Unable to connect to cloudtrail %s in order to "
                         "enumerate CloudTrails in region %s due to %s" %


### PR DESCRIPTION
Remove cloudtrail logic which hard codes the S3 bucket name if the script can not authenticate to the target AWS account.

https://bugzilla.mozilla.org/show_bug.cgi?id=1217976

Reverts portion of f84e9726a703147295ea07c2ac56378ad353c945