### PR TITLE
Improve logic on which messages will be filtered by the IRC bot

### DIFF
--- a/alerts/lib/alerttask.py
+++ b/alerts/lib/alerttask.py
@@ -206,7 +206,7 @@ class AlertTask(Task):
             alert['notify_mozdefbot'] = False
 
         # If an alert sets specific ircchannel, then we should probably always notify in mozdefbot
-        if 'ircchannel' in alert:
+        if 'ircchannel' in alert and ('ircchannel' != "" and 'ircchannel' != None):
             alert['notify_mozdefbot'] = True
         return alert
 

--- a/alerts/lib/alerttask.py
+++ b/alerts/lib/alerttask.py
@@ -206,7 +206,7 @@ class AlertTask(Task):
             alert['notify_mozdefbot'] = False
 
         # If an alert sets specific ircchannel, then we should probably always notify in mozdefbot
-        if 'ircchannel' in alert and ('ircchannel' != "" and 'ircchannel' != None):
+        if 'ircchannel' in alert and alert['ircchannel'] != '' and alert['ircchannel'] != None:
             alert['notify_mozdefbot'] = True
         return alert
 


### PR DESCRIPTION
Fixes the alert logic to ensure that if an IRC channel is specified, the message will be displayed by the bot