### PR TITLE
Add Python 2.7.12 and 2.7.13 to CI coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - '2.7.11'
+  - '2.7.12'
+  - '2.7.13'
 before_install:
   - ES_VERSION=2.4.4; curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.deb && sudo dpkg -i --force-confnew elasticsearch-${ES_VERSION}.deb && sudo service elasticsearch restart
   - sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime


### PR DESCRIPTION
Supports: https://github.com/mozilla/MozDef/issues/406