### PR TITLE
add gcc-c++ to avoid missing g++ during bcrypt build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN \
                     java-$ES_JAVA_VERSION \
                     glibc-devel \
                     gcc \
+                    gcc-c++ \
                     libstdc++ \
                     supervisor \
                     libffi-devel \

--- a/docker/compose/mozdef_meteor/Dockerfile
+++ b/docker/compose/mozdef_meteor/Dockerfile
@@ -16,6 +16,17 @@ RUN \
   cd /opt/mozdef && \
   curl -sL -o /opt/mozdef/nodesource.rpm https://rpm.nodesource.com/pub_4.x/el/7/x86_64/nodesource-release-el7-1.noarch.rpm && \
   rpm -i --nosignature --force /opt/mozdef/nodesource.rpm && \
+  yum install -y \
+                    wget \
+                    make \
+                    glibc-devel \
+                    gcc \
+                    gcc-c++ \
+                    libstdc++ \
+                    supervisor \
+                    libffi-devel \
+                    zlib-devel \
+                    cronie && \
   yum install -y nodejs-$NODE_VERSION && \
   npm install source-map-support@0.4.2 \
                  semver@5.3.0 \


### PR DESCRIPTION
Just tried building and was missing g++ when node tries to build bcrypt. Here's a patch to add it.