### PR TITLE
fix "too many items" problem in the tags pivot table

### DIFF
--- a/meteor/app/client/incidentsveris.js
+++ b/meteor/app/client/incidentsveris.js
@@ -46,7 +46,8 @@ if (Meteor.isClient) {
                         tableData,
                         {
                             cols: ["phase"],
-                            rows: ["tags"]
+                            rows: ["tags"],
+                            menuLimit: 500,
                         }
                     );
         }


### PR DESCRIPTION
Currently we are using the default 50 item limit for tags, which we overrun quickly when tagging incidents. The pivot table can handle quite a bit more, this just ups the limit to avoid the dreaded: 
<img width="455" alt="screen shot 2017-08-25 at 1 45 07 pm" src="https://user-images.githubusercontent.com/566889/29735252-6dfbb27e-89ac-11e7-8190-240131cbbd36.png">
