### PR TITLE
Modify logger level in backup snapshot cron

### DIFF
--- a/cron/backupSnapshot.py
+++ b/cron/backupSnapshot.py
@@ -36,7 +36,6 @@ import json
 from os.path import expanduser
 
 logger = logging.getLogger(sys.argv[0])
-logger.level=logging.DEBUG
 formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
 
 


### PR DESCRIPTION
This prevents the cron email from reporting even when the script executes as expected.