### PR TITLE
Add fluentd container to consume syslog logs

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -199,7 +199,7 @@ services:
     depends_on:
       - loginput
     ports:
-      - 514:514
+      - 514:514/udp
     networks:
       - default
 

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -200,6 +200,7 @@ services:
       - loginput
     ports:
       - 514:514/udp
+      - 514:514
     networks:
       - default
 

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -190,6 +190,18 @@ services:
       - 8081:8081
     networks:
       - default
+  fluentd:
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_fluentd/Dockerfile
+    restart: always
+    command: bash -c '/usr/local/bundle/bin/fluentd -c /etc/fluent/fluent.conf'
+    depends_on:
+      - loginput
+    ports:
+      - 514:514
+    networks:
+      - default
 
 volumes:
   elasticsearch:

--- a/docker/compose/mozdef_fluentd/Dockerfile
+++ b/docker/compose/mozdef_fluentd/Dockerfile
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+#
+# Contributors:
+# Andrew Krug akrug@mozilla.com
+# Brandon Myers bmyers@mozilla.com
+
+FROM ruby:2.2.0
+
+MAINTAINER mozdef@mozilla.com
+
+RUN \
+  gem install fluentd -v "~>0.14" && \
+  mkdir /etc/fluent && \
+  gem install fluent-plugin-out-http
+
+COPY docker/compose/mozdef_fluentd/files/fluent.conf /etc/fluent/fluent.conf
+
+EXPOSE 514

--- a/docker/compose/mozdef_fluentd/files/fluent.conf
+++ b/docker/compose/mozdef_fluentd/files/fluent.conf
@@ -1,16 +1,16 @@
 <source>
-  @type syslog
+  @type tcp
+  format none
+  tag syslog
   port 514
   bind 0.0.0.0
-  protocol_type udp
-  tag syslog
 </source>
 <source>
-  @type syslog
+  @type udp
+  format none
+  tag syslog
   port 514
   bind 0.0.0.0
-  protocol_type tcp
-  tag syslog
 </source>
 
 <match syslog.**>

--- a/docker/compose/mozdef_fluentd/files/fluent.conf
+++ b/docker/compose/mozdef_fluentd/files/fluent.conf
@@ -1,0 +1,12 @@
+<source>
+  @type syslog
+  port 514
+  bind 0.0.0.0
+  tag syslog
+</source>
+
+<match syslog.**>
+  type http
+  endpoint_url    http://loginput:8080/events/
+  serializer      json
+</match>

--- a/docker/compose/mozdef_fluentd/files/fluent.conf
+++ b/docker/compose/mozdef_fluentd/files/fluent.conf
@@ -6,7 +6,7 @@
 </source>
 
 <match syslog.**>
-  type http
+  @type http
   endpoint_url    http://loginput:8080/events/
   serializer      json
 </match>

--- a/docker/compose/mozdef_fluentd/files/fluent.conf
+++ b/docker/compose/mozdef_fluentd/files/fluent.conf
@@ -2,11 +2,19 @@
   @type syslog
   port 514
   bind 0.0.0.0
+  protocol_type udp
+  tag syslog
+</source>
+<source>
+  @type syslog
+  port 514
+  bind 0.0.0.0
+  protocol_type tcp
   tag syslog
 </source>
 
 <match syslog.**>
   @type http
-  endpoint_url    http://loginput:8080/events/
-  serializer      json
+  endpoint_url http://loginput:8080/events/
+  serializer json
 </match>


### PR DESCRIPTION
This will provide a 'syslog server' interface for sending events to mozdef.