### PR TITLE
Fixes #421 - Changed python virtualenv to /opt/mozdef/envs/python in all cron/*.sh files

### DIFF
--- a/cron/auth02mozdef.sh
+++ b/cron/auth02mozdef.sh
@@ -6,5 +6,5 @@
 # Author: gdestuynder@mozilla.com
 
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/auth02mozdef.py
+source  /opt/mozdef/envs/python/mozdef/bin/activate
+/opt/mozdef/envs/python/mozdef/cron/auth02mozdef.py

--- a/cron/backupSnapshot.sh
+++ b/cron/backupSnapshot.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Anthony Verez averez@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/backupSnapshot.py -c /opt/mozdef/envs/mozdef/cron/backup.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/backupSnapshot.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/backup.conf

--- a/cron/collectAttackers.sh
+++ b/cron/collectAttackers.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/collectAttackers.py -c /opt/mozdef/envs/mozdef/cron/collectAttackers.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/collectAttackers.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/collectAttackers.conf

--- a/cron/collectSSHFingerprints.sh
+++ b/cron/collectSSHFingerprints.sh
@@ -8,6 +8,6 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/collectSSHFingerprints.py -c /opt/mozdef/envs/mozdef/cron/collectSSHFingerprints.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/collectSSHFingerprints.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/collectSSHFingerprints.conf
 

--- a/cron/correlateUserMacAddress.sh
+++ b/cron/correlateUserMacAddress.sh
@@ -8,6 +8,6 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/correlateUserMacAddress.py -c /opt/mozdef/envs/mozdef/cron/correlateUserMacAddress.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/correlateUserMacAddress.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/correlateUserMacAddress.conf
 

--- a/cron/createIPBlockList.sh
+++ b/cron/createIPBlockList.sh
@@ -8,6 +8,6 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/createIPBlockList.py -c /opt/mozdef/envs/mozdef/cron/createIPBlockList.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/createIPBlockList.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/createIPBlockList.conf
 

--- a/cron/duo_logpull.sh
+++ b/cron/duo_logpull.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/duo_logpull.py -c /opt/mozdef/envs/mozdef/cron/duo_logpull.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/duo_logpull.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/duo_logpull.conf

--- a/cron/esMaint.sh
+++ b/cron/esMaint.sh
@@ -8,6 +8,6 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/rotateIndexes.py -c /opt/mozdef/envs/mozdef/cron/backup.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/rotateIndexes.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/backup.conf
 

--- a/cron/eventStats.sh
+++ b/cron/eventStats.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Brandon Myers bmyers@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/eventStats.py -c /opt/mozdef/envs/mozdef/cron/eventStats.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/eventStats.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/eventStats.conf

--- a/cron/google2mozdef.sh
+++ b/cron/google2mozdef.sh
@@ -8,6 +8,6 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/google2mozdef.py -c /opt/mozdef/envs/mozdef/cron/google2mozdef.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/google2mozdef.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/google2mozdef.conf
 

--- a/cron/healthAndStatus-fxa.sh
+++ b/cron/healthAndStatus-fxa.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Brandon Myers bmyers@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/healthAndStatus.py -c /opt/mozdef/envs/mozdef/cron/healthAndStatus.fxa.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/healthAndStatus.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/healthAndStatus.fxa.conf

--- a/cron/healthAndStatus.sh
+++ b/cron/healthAndStatus.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/healthAndStatus.py -c /opt/mozdef/envs/mozdef/cron/healthAndStatus.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/healthAndStatus.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/healthAndStatus.conf

--- a/cron/healthToMongo.sh
+++ b/cron/healthToMongo.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Brandon Myers bmyers@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/healthToMongo.py -c /opt/mozdef/envs/mozdef/cron/healthToMongo.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/healthToMongo.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/healthToMongo.conf

--- a/cron/import_threat_exchange.sh
+++ b/cron/import_threat_exchange.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Brandon Myers bmyers@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/import_threat_exchange.py -c /opt/mozdef/envs/mozdef/cron/import_threat_exchange.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/import_threat_exchange.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/import_threat_exchange.conf

--- a/cron/okta2mozdef.sh
+++ b/cron/okta2mozdef.sh
@@ -8,6 +8,6 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/okta2mozdef.py -c /opt/mozdef/envs/mozdef/cron/okta2mozdef.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/okta2mozdef.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/okta2mozdef.conf
 

--- a/cron/pruneES.sh
+++ b/cron/pruneES.sh
@@ -8,6 +8,6 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/pruneIndexes.py -c /opt/mozdef/envs/mozdef/cron/backup.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/pruneIndexes.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/backup.conf
 

--- a/cron/syncAlertsToMongo.sh
+++ b/cron/syncAlertsToMongo.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.py -c /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/syncAlertsToMongo.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/syncAlertsToMongo.conf

--- a/cron/update_generic_alerts.sh
+++ b/cron/update_generic_alerts.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Brandon Myers bmyers@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/update_generic_alerts.py -c /opt/mozdef/envs/mozdef/cron/update_generic_alerts.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/update_generic_alerts.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/update_generic_alerts.conf

--- a/cron/update_geolite_db.sh
+++ b/cron/update_geolite_db.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Brandon Myers bmyers@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/update_geolite_db.py -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/update_geolite_db.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/update_geolite_db.conf

--- a/cron/update_ip_list.sh
+++ b/cron/update_ip_list.sh
@@ -8,5 +8,5 @@
 # Contributors:
 # Brandon Myers bmyers@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/update_ip_list.py -c /opt/mozdef/envs/mozdef/cron/update_ip_list.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/update_ip_list.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/update_ip_list.conf

--- a/cron/vidyo2MozDef.sh
+++ b/cron/vidyo2MozDef.sh
@@ -8,6 +8,6 @@
 # Contributors:
 # Jeff Bryner jbryner@mozilla.com
 
-source  /opt/mozdef/envs/mozdef/bin/activate
-/opt/mozdef/envs/mozdef/cron/vidyo2MozDef.py -c /opt/mozdef/envs/mozdef/cron/vidyo2MozDef.conf
+source  //opt/mozdef/envs/python/pythonpython/mozdef/bin/activate
+//opt/mozdef/envs/python/pythonpython/mozdef/cron/vidyo2MozDef.py -c //opt/mozdef/envs/python/pythonpython/mozdef/cron/vidyo2MozDef.conf
 


### PR DESCRIPTION
Changed python virtualenv to /opt/mozdef/envs/python in all cron/*.sh files