### PR TITLE
Suppress mkdir exit status in systemd files

### DIFF
--- a/systemdfiles/alert/mozdefalertplugins.service
+++ b/systemdfiles/alert/mozdefalertplugins.service
@@ -5,7 +5,7 @@ After=rabbitmq-server.service
 [Service]
 # Requires systemd version 211 or newer
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/mkdir /var/run/mozdef-alerts
+ExecStartPre=-/usr/bin/mkdir -p /var/run/mozdef-alerts
 ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdef-alerts
 User=mozdef
 Group=mozdef

--- a/systemdfiles/alert/mozdefalerts.service
+++ b/systemdfiles/alert/mozdefalerts.service
@@ -5,7 +5,7 @@ After=rabbitmq-server.service
 [Service]
 # Requires systemd version 211 or newer
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/mkdir /var/run/mozdef-alerts
+ExecStartPre=-/usr/bin/mkdir -p /var/run/mozdef-alerts
 ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdef-alerts
 PIDFile=/var/run/mozdef-alerts/supervisord.pid
 User=mozdef

--- a/systemdfiles/alert/mozdefbot.service
+++ b/systemdfiles/alert/mozdefbot.service
@@ -5,7 +5,7 @@ After=rabbitmq-server.service
 [Service]
 # Requires systemd version 211 or newer
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/mkdir /var/run/mozdefbot
+ExecStartPre=-/usr/bin/mkdir -p /var/run/mozdefbot
 ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdefbot/
 User=mozdef
 Group=mozdef

--- a/systemdfiles/alert/mozdefloginput.service
+++ b/systemdfiles/alert/mozdefloginput.service
@@ -5,7 +5,7 @@ After=rabbitmq-server.service
 [Service]
 # Requires systemd version 211 or newer
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/mkdir /var/run/mozdef-loginput
+ExecStartPre=-/usr/bin/mkdir -p /var/run/mozdef-loginput
 ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdef-loginput/
 User=mozdef
 Group=mozdef

--- a/systemdfiles/consumer/mozdefloginput.service
+++ b/systemdfiles/consumer/mozdefloginput.service
@@ -5,7 +5,7 @@ After=rabbitmq-server.service
 [Service]
 # Requires systemd version 211 or newer
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/mkdir /var/run/mozdef-loginput
+ExecStartPre=-/usr/bin/mkdir -p /var/run/mozdef-loginput
 ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdef-loginput/
 User=mozdef
 Group=mozdef

--- a/systemdfiles/consumer/mozdefmqwsyslog.service
+++ b/systemdfiles/consumer/mozdefmqwsyslog.service
@@ -5,7 +5,7 @@ After=rabbitmq-server.service
 [Service]
 # Requires systemd version 211 or newer
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/mkdir /var/run/mozdefmqwSyslog
+ExecStartPre=-/usr/bin/mkdir -p /var/run/mozdefmqwSyslog
 ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdefmqwSyslog
 User=mozdef
 Group=mozdef

--- a/systemdfiles/web/mongod.service
+++ b/systemdfiles/web/mongod.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=forking
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/mkdir /var/run/mozdefdb
+ExecStartPre=-/usr/bin/mkdir -p /var/run/mozdefdb
 ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdefdb/
 PIDFile=/var/run/mozdefdb/mozdefdb.pid
 ExecStart=/usr/bin/mongod  --storageEngine=mmapv1 --config /etc/mongod.conf --syslog

--- a/systemdfiles/web/mozdefrestapi.service
+++ b/systemdfiles/web/mozdefrestapi.service
@@ -5,7 +5,7 @@ After=mozdefweb.service
 [Service]
 # Requires systemd version 211 or newer
 PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/mkdir /var/run/mozdef-rest
+ExecStartPre=-/usr/bin/mkdir -p /var/run/mozdef-rest
 ExecStartPre=/usr/bin/chown -R mozdef:mozdef /var/run/mozdef-rest/
 User=mozdef
 Group=mozdef


### PR DESCRIPTION
This fixes the issue of "ExecStartPre=/usr/bin/mkdir /var/run/mozdef-alerts (code=exited, status=1/FAILURE)" showing up in red text in the output of 'systemctl status <mozdefservicename>'.