### PR TITLE
Misc docker fixes

### DIFF
--- a/docker/compose/mozdef_meteor/Dockerfile
+++ b/docker/compose/mozdef_meteor/Dockerfile
@@ -2,9 +2,10 @@ FROM centos:7
 
 MAINTAINER mozdef@mozilla.com
 
+#updated meteor version to avoid EXDEV: cross-device link not permitted errors
 ENV NODE_VERSION 4.7.0
-ENV METEOR_VERSION 1.4.0.1
-ENV METEOR_FILE_VERSION 1.4.0-1
+ENV METEOR_VERSION 1.4.4.2
+ENV METEOR_FILE_VERSION 1.4.4-1
 
 ENV MONGO_URL=mongodb://mongodb:3002/meteor
 ENV ROOT_URL=http://localhost
@@ -37,12 +38,16 @@ RUN \
   tar -xzf /opt/mozdef/meteor.tar.gz -C /opt/mozdef/meteor && \
   mv /opt/mozdef/meteor/.meteor /opt/mozdef && \
   rm -r /opt/mozdef/meteor && \
-  cp /opt/mozdef/.meteor/packages/meteor-tool/$METEOR_FILE_VERSION/mt-os.linux.x86_64/scripts/admin/launch-meteor /usr/bin/meteor
+  cp /opt/mozdef/.meteor/packages/meteor-tool/*/mt-os.linux.x86_64/scripts/admin/launch-meteor /usr/bin/meteor
 
+#copy our source dir and set ownership
+USER mozdef
 COPY meteor /opt/mozdef/envs/mozdef/meteor
+USER root
 RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/meteor
-RUN chown -R mozdef:mozdef /opt/mozdef/
 
+#avoiding -R due to massive list of files from meteor
+RUN chown  mozdef:mozdef /opt/mozdef/envs
 USER mozdef
 RUN \
   cd /opt/mozdef/envs/mozdef/meteor && \

--- a/docker/compose/mozdef_meteor/files/settings.js
+++ b/docker/compose/mozdef_meteor/files/settings.js
@@ -13,7 +13,7 @@ Brandon Myers bmyers@mozilla.com
 //configuration settings
 
 mozdef = {
-  rootURL: "localhost",
+  rootURL: "http://localhost",
   port: "80",
   rootAPI: "http://rest:8081",
   kibanaURL: "http://localhost:9090/app/kibana#",

--- a/meteor/app/client/attackers.js
+++ b/meteor/app/client/attackers.js
@@ -303,7 +303,7 @@ if (Meteor.isClient) {
             //default selection criteria
             //$and will be used by the charts
             basecriteria={$and: [
-                                {lastseentimestamp: {$gte: moment(0)._d}}
+                                {lastseentimestamp: {$exists: true}}
                                 ]
                     }
             return basecriteria;


### PR DESCRIPTION
Variety of fixes for issues I encountered in the 'multiple' docker build. 

Probably the biggest is: For me, it wouldn't even build complaining of an EXDEV error that appears to be fixed in the subsequent version of meteor. So bumped the version. 

Minor but still intriguing is a change to the attacker selection criteria due to the date always being init'd as now() rather than 1970.

The chown -R is removed since it touches thousands of files, takes forever on a rebuild, and isn't really needed if we just chown the dir. 