### PR TITLE
Add ssh password auth violation alert

### DIFF
--- a/alerts/ssh_password_auth_violation.py
+++ b/alerts/ssh_password_auth_violation.py
@@ -34,11 +34,7 @@ class AlertSSHPasswordAuthViolation(AlertTask):
         category = 'ssh_password_auth_policy_violation'
         tags = ['ssh_password_auth_policy_violation']
         severity = 'WARNING'
-
-        summary = ('SSH password authentication allowed on {0} ('.format(aggreg['value']))
-        for event in aggreg['events'][:5]:
-            summary += str(event['_source']['details']['destinationport']) + ' '
-        summary += ')'
+        summary = 'SSH password authentication allowed on {0}'.format(aggreg['value'])
 
         # Create the alert object based on these properties
         return self.createAlertDict(summary, category, tags, aggreg['events'], severity)

--- a/alerts/ssh_password_auth_violation.py
+++ b/alerts/ssh_password_auth_violation.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+from lib.alerttask import AlertTask
+from query_models import SearchQuery, TermMatch, PhraseMatch
+
+
+class AlertSSHPasswordAuthViolation(AlertTask):
+    def main(self):
+        search_query = SearchQuery(hours=4)
+
+        search_query.add_must([
+            TermMatch('_type', 'event'),
+            PhraseMatch('tags', 'ssh_password_auth_policy_violation'),
+        ])
+
+        self.filtersManual(search_query)
+
+        # Search aggregations on field 'sourceipaddress', keep X samples of
+        # events at most
+        self.searchEventsAggregated('details.destinationipaddress', samplesLimit=100)
+        # alert when >= X matching events in an aggregation
+        self.walkAggregations(threshold=1)
+
+    # Set alert properties
+    def onAggregation(self, aggreg):
+        # aggreg['count']: number of items in the aggregation, ex: number of failed login attempts
+        # aggreg['value']: value of the aggregation field, ex: toto@example.com
+        # aggreg['events']: list of events in the aggregation
+        category = 'ssh_password_auth_policy_violation'
+        tags = ['ssh_password_auth_policy_violation']
+        severity = 'WARNING'
+
+        summary = ('SSH password authentication allowed on {0} ('.format(aggreg['value']))
+        for event in aggreg['events'][:5]:
+            summary += str(event['_source']['details']['destinationport']) + ' '
+        summary += ')'
+
+        # Create the alert object based on these properties
+        return self.createAlertDict(summary, category, tags, aggreg['events'], severity)

--- a/tests/alerts/test_ssh_password_auth_violation.py
+++ b/tests/alerts/test_ssh_password_auth_violation.py
@@ -1,0 +1,75 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+from positive_alert_test_case import PositiveAlertTestCase
+from negative_alert_test_case import NegativeAlertTestCase
+
+from alert_test_suite import AlertTestSuite
+
+
+class TestAlertSSHPasswordAuthViolation(AlertTestSuite):
+    alert_filename = "ssh_password_auth_violation"
+
+    # This event is the default positive event that will cause the
+    # alert to trigger
+    default_event = {
+        "_type": "event",
+        "_source": {
+            "tags": ["ssh_password_auth_policy_violation"],
+            "details": {
+                "destinationipaddress": "1.2.3.4",
+                "destinationport": 22,
+            }
+        }
+    }
+
+    # This alert is the expected result from running this task
+    default_alert = {
+        "category": "ssh_password_auth_policy_violation",
+        "tags": ['ssh_password_auth_policy_violation'],
+        "severity": "CRITICAL",
+        "summary": 'SSH password authentication allowed on 1.2.3.4',
+    }
+
+    test_cases = []
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test with default events and default alert expected",
+            events=AlertTestSuite.create_events(default_event, 1),
+            expected_alert=default_alert
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_type'] = 'bad'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with events with incorrect _type",
+            events=events,
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_source']['tags'] = 'bad tag example'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with events with incorrect tags",
+            events=events,
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 241})
+        event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 241})
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with old timestamp",
+            events=events,
+        )
+    )

--- a/tests/alerts/test_ssh_password_auth_violation.py
+++ b/tests/alerts/test_ssh_password_auth_violation.py
@@ -29,7 +29,7 @@ class TestAlertSSHPasswordAuthViolation(AlertTestSuite):
     default_alert = {
         "category": "ssh_password_auth_policy_violation",
         "tags": ['ssh_password_auth_policy_violation'],
-        "severity": "CRITICAL",
+        "severity": "WARNING",
         "summary": 'SSH password authentication allowed on 1.2.3.4',
     }
 


### PR DESCRIPTION
This adds warning alerts in cases where a public ssh endpoint is detected that allows password auth, which is a no-no.