### PR TITLE
new cron to update aliases, removed events alias update from rotateIndexes.py

### DIFF
--- a/cron/rollover_index_aliases.sh
+++ b/cron/rollover_index_aliases.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This is a temporary fix only
+
+if ! [ -x "$(command -v curl)" ]; then
+  exit 1
+fi
+
+alias_exists=`curl -s -XGET mozdef.private.scl3.mozilla.com:9200/_cat/aliases | grep "events\s"`
+events_index=`curl -s -XGET mozdef.private.scl3.mozilla.com:9200/_cat/events | grep "events\s"`
+rotate_alias=`curl -s -XGET mozdef.private.scl3.mozilla.com:9200/_cat/events | grep "events\s"`
+index_current_date=`date +%Y%m%d`
+index_new_date=$((index_current_date+1))
+index_old_date=$((index_current_date-1))
+successful_connect=`curl -s -XGET mozdef.private.scl3.mozilla.com:9200`
+
+if [[ "${successful_connect}" == *"name"* ]]; then
+  printf "We connected successfully with curl.\n"
+else
+  exit 1
+fi
+
+if [[ "${alias_exists}" == "events "* ]]; then
+  printf "Event alias exists.\n"
+else
+  if [[ "${events_index}" == "events "* ]]; then
+    exit 1
+  fi
+fi
+
+printf "Rolling over events alias."
+curl -XPOST mozdef.private.scl3.mozilla.com:9200/_aliases -d' { "actions": [{ "add" : { "index" : "events-'${index_new_date}'", "alias" : "events" } }, { "remove" : { "index" : "events-'${index_current_date}'", "alias" : "events" } } ]}'
+
+printf "Rolling over events-previous alias."
+curl -XPOST mozdef.private.scl3.mozilla.com:9200/_aliases -d' { "actions": [{ "add" : { "index" : "events-'${index_current_date}'", "alias" : "events-previous" } }, { "remove" : { "index" : "events-'${index_old_date}'", "alias" : "events-previous" } }, { "remove" : { "index" : "events-'${index_old_date}'", "alias" : "events-previous" } } ]}'

--- a/cron/rotateIndexes.py
+++ b/cron/rotateIndexes.py
@@ -80,15 +80,6 @@ def esRotateIndexes():
                     if newindex not in indices:
                         logger.debug('Creating %s index' % newindex)
                         es.create_index(newindex)
-                    # set aliases: events to events-YYYYMMDD
-                    # and events-previous to events-YYYYMMDD-1 for example
-                    logger.debug('Setting {0} alias to index: {1}'.format(index, newindex))
-                    es.create_alias(index, newindex)
-                    if oldindex in indices:
-                        logger.debug('Setting {0}-previous alias to index: {1}'.format(index, oldindex))
-                        es.create_alias('%s-previous' % index, oldindex)
-                    else:
-                        logger.debug('Old index %s is missing, do not change %s-previous alias' % (oldindex, index))
             except Exception as e:
                 logger.error("Unhandled exception while rotating %s, terminating: %r" % (index, e))
 


### PR DESCRIPTION
- removed events alias rotation from rotateIndexes.py
- added cron to rotate events alias only

Tested on development mozdef host successfully.

events-previous events-20171020 - - - 
alerts          alerts-201710   - - - 
alerts-previous alerts-201707   - - - 
events          events-20171021 - - -