### PR TITLE
Resolve dashboard URLs

### DIFF
--- a/rest/index.py
+++ b/rest/index.py
@@ -547,9 +547,8 @@ def kibanaDashboards():
         for dashboard in results['hits']:
             resultsList.append({
                 'name': dashboard['_source']['title'],
-                'url': "%s/%s/%s" % (options.kibanaurl,
-                "dashboard",
-                dashboard['_source']['title'])
+                'url': "%s/%s" % (options.kibanaurl,
+                dashboard['_id'])
             })
 
     except ElasticsearchInvalidIndex as e:


### PR DESCRIPTION
switched from using _source:title for dashboard url name to using _id.
Tested live on aws gold image and docker build - works!