### PR TITLE
Docker nginx redirect fix

### DIFF
--- a/docker/compose/nginx/files/nginx.conf
+++ b/docker/compose/nginx/files/nginx.conf
@@ -71,7 +71,7 @@ http {
       proxy_set_header     X-Forwarded-Proto   $scheme;
       proxy_cache_bypass   $http_upgrade;
       rewrite              /kibana/(.*)$ /$1 break;
-      proxy_redirect       http://127.0.0.1:5601 https://localhost:9443;
+      proxy_redirect       http://127.0.0.1:5601 https://localhost:9090;
     }
     location ~ ^/_aliases$ {
       proxy_pass http://elasticsearch:9200;

--- a/rest/index.py
+++ b/rest/index.py
@@ -547,9 +547,8 @@ def kibanaDashboards():
         for dashboard in results['hits']:
             resultsList.append({
                 'name': dashboard['_source']['title'],
-                'url': "%s/%s/%s" % (options.kibanaurl,
-                "dashboard",
-                dashboard['_source']['title'])
+                'url': "%s/%s" % (options.kibanaurl,
+                dashboard['_id'])
             })
 
     except ElasticsearchInvalidIndex as e:


### PR DESCRIPTION
Since we don't have ssl in the docker containers, removing redirect to ssl port as this sometimes breaks things (like dashboards)