### PR TITLE
Modifying rest index test to reflect nature of actual kibana links

### DIFF
--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -66,10 +66,10 @@ class TestKibanaDashboardsRoute(RestTestSuite):
 
             json_resp.sort()
 
-            assert json_resp[1]['url'].endswith("/app/kibana#/dashboard/Example SSH Dashboard") is True
+            assert json_resp[1]['url'].endswith("/app/kibana#/dashboard/Example-SSH-Dashboard") is True
             assert json_resp[1]['name'] == 'Example SSH Dashboard'
 
-            assert json_resp[0]['url'].endswith("/app/kibana#/dashboard/Example FTP Dashboard") is True
+            assert json_resp[0]['url'].endswith("/app/kibana#/dashboard/Example-FTP-Dashboard") is True
             assert json_resp[0]['name'] == 'Example FTP Dashboard'
 
 


### PR DESCRIPTION
In Kibana link URL's  spaces are really dashes