### PR TITLE
Modifying size of the font and image

### DIFF
--- a/meteor/public/css/mozdef.css
+++ b/meteor/public/css/mozdef.css
@@ -311,12 +311,12 @@ circle:hover{
     color:white;
     text-shadow: #000 5px 3px 3px;
     text-align: center;
-    font-size: 1.5vw;
+    font-size: 1vw;
     margin-top: -.25em;
 }
 
 .mozillalogo{
-    width: 7vw;
+    width: 5vw;
 }
 
 #header label{


### PR DESCRIPTION
in relation to the menu bar on screen resizing. Works on 4k.

Previously the logo and name were HUGE on a 4k screen compared to the menu options.
Have tested this on 4k and regular 1080p