### PR TITLE
Adding mandatory fields to mapping.

### DIFF
--- a/config/defaultMappingTemplate.json
+++ b/config/defaultMappingTemplate.json
@@ -76,6 +76,36 @@
           }
         } ],
         "properties" : {
+          "category" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "doc_values" : true
+          },
+          "hostname" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "doc_values" : true
+          },
+          "processid" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "doc_values" : true
+          },
+          "processname": {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "doc_values": true
+          },
+          "severity" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "doc_values" : true
+          },
+          "source" : {
+            "type" : "string",
+            "index" : "not_analyzed",
+            "doc_values" : true
+          },
           "summary" : {
             "type" : "string"
           },


### PR DESCRIPTION
I found that tags are currently entered as a string, but @pwnbus mentioned them being an array.
There are some items that I didn't add to this defaulttemplate, and figure we can discuss those items at a later date after the holiday. The fields with the most potential of being added as a number or other field type other than string are what have been added here.