### PR TITLE
Update geomodel alert to exclude additional attributes logic

### DIFF
--- a/alerts/geomodel.py
+++ b/alerts/geomodel.py
@@ -7,6 +7,7 @@
 #
 # Contributors:
 # Aaron Meihm <ameihm@mozilla.com>
+# Brandon Myers <bmyers@mozilla.com>
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch
@@ -51,11 +52,12 @@ class AlertGeomodel(AlertTask):
         summary = ev['summary']
         alert_dict = self.createAlertDict(summary, category, tags, [event], severity)
 
-        alert_dict['details'] = {
-            'locality_details': ev['details']['locality_details'],
-            'category': ev['details']['category'],
-            'principal': ev['details']['principal'],
-            'source_ip': ev['details']['source_ipv4']
-        }
+        if 'category' in ev['details'] and ev['details']['category'].lower() == 'newcountry':
+            alert_dict['details'] = {
+                'locality_details': ev['details']['locality_details'],
+                'category': ev['details']['category'],
+                'principal': ev['details']['principal'],
+                'source_ip': ev['details']['source_ipv4']
+            }
 
         return alert_dict

--- a/tests/alerts/test_geomodel.py
+++ b/tests/alerts/test_geomodel.py
@@ -82,6 +82,32 @@ class TestAlertGeomodel(AlertTestSuite):
         )
     )
 
+    movement_event = {
+        "_source": {
+            u'category': u'geomodelnotice',
+            u'details': {
+                'category': 'MOVEMENT',
+            },
+            'severity': 'NOTICE',
+            'source': 'UNKNOWN',
+            'summary': 'person1@mozilla.com MOVEMENT window violation (London, United Kingdom) -> (San Jose, United States) -> (Frankfurt am Main, Germany) within 4h window',
+        }
+    }
+    movement_alert = {
+        "category": "geomodel",
+        "tags": ['geomodel'],
+        "severity": "NOTICE",
+        "notify_mozdefbot": False,
+        "summary": "person1@mozilla.com MOVEMENT window violation (London, United Kingdom) -> (San Jose, United States) -> (Frankfurt am Main, Germany) within 4h window",
+    }
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test case with multiple localities",
+            events=[AlertTestSuite.create_event(movement_event)],
+            expected_alert=movement_alert
+        )
+    )
+
     event = AlertTestSuite.create_event(default_event)
     event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 31})
     event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 31})


### PR DESCRIPTION
This fixes the 'locality_details' error we're seeing in the alert error logs. 

This is due to the fact that movement alerts don't have the specific fields that we are about setting in 'details'. Since we aren't sending movement alerts to the SSO dashboard, we can simply ignore setting those fields.