### PR TITLE
Center the header

### DIFF
--- a/meteor/app/client/menu.html
+++ b/meteor/app/client/menu.html
@@ -10,7 +10,7 @@ Alicia Smith asmith@mozilla.com
 -->
 
 <template name="menu">
-    <div class="container">
+    <div class="container headercontainer">
         <div id="header"  class="row center">
             <span id="nav-main">
             <ul>

--- a/meteor/public/css/mozdef.css
+++ b/meteor/public/css/mozdef.css
@@ -60,6 +60,12 @@ caption, legend {
 
 }
 
+.headercontainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 #header a.mozilla {
     position: relative;
     float: right;

--- a/meteor/public/css/mozdef.css
+++ b/meteor/public/css/mozdef.css
@@ -317,12 +317,12 @@ circle:hover{
     color:white;
     text-shadow: #000 5px 3px 3px;
     text-align: center;
-    font-size: 1vw;
+    font-size: large;
     margin-top: -.25em;
 }
 
 .mozillalogo{
-    width: 5vw;
+    width: 90px;
 }
 
 #header label{


### PR DESCRIPTION
Logo size change moved the menu header to the right, no longer centers. This fixes.