### PR TITLE
Adding creator column to investigations and incidents

### DIFF
--- a/meteor/app/client/incidentTable.html
+++ b/meteor/app/client/incidentTable.html
@@ -21,6 +21,7 @@ Anthony Verez averez@mozilla.com
                         <td>Summary</td>
                         <td>Phase</td>
                         <td>Opened</td>
+                        <td>By</td>
                         <td>Closed</td>
                         <td></td>
                     </tr>
@@ -42,7 +43,8 @@ Anthony Verez averez@mozilla.com
                 <td><button class="btn btn-xs btn-default incidentedit" data-incidentid={{_id}}>edit</button></td>
 				<td>{{summary}}</td>
                 <td>{{phase}}</td>
-				<td>{{dateOpened}}</td>
+                <td>{{dateOpened}}</td>
+                <td>{{creator}}</td>
 				<td>{{dateClosed}}</td>
                 <td><button class="btn btn-xs btn-warning" data-toggle="collapse" data-target="#delete{{_id}}">arm delete</button>
                     <div id="delete{{_id}}" class="collapse">

--- a/meteor/app/client/investigationTable.html
+++ b/meteor/app/client/investigationTable.html
@@ -21,6 +21,7 @@ Jeff Bryner jbryner@mozilla.com
                         <td>Summary</td>
                         <td>Phase</td>
                         <td>Opened</td>
+                        <td>By</td>
                         <td>Closed</td>
                         <td></td>
                     </tr>
@@ -42,7 +43,8 @@ Jeff Bryner jbryner@mozilla.com
                 <td><button class="btn btn-xs btn-default investigationedit" data-incidentid={{_id}}>edit</button></td>
 				<td>{{summary}}</td>
                 <td>{{phase}}</td>
-				<td>{{dateOpened}}</td>
+                <td>{{dateOpened}}</td>
+                <td>{{creator}}</td>
 				<td>{{dateClosed}}</td>
                 <td><button class="btn btn-xs btn-warning" data-toggle="collapse" data-target="#delete{{_id}}">arm delete</button>
                     <div id="delete{{_id}}" class="collapse">


### PR DESCRIPTION
As a part of the UI Interviews it was stated it would be nice to see who opened an investigation or incident without having to hover over the entry. 
This adds this functionality.