### PR TITLE
Remove free-form 'Contributor:' text from code. Fixes #407

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# 2xyo <yohann@lepage.info>
-# Yohann Lepage yohann@lepage.info
-# Anthony Verez averez@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 # usage:
 # make single-build - build new single image from Dockerfile

--- a/alerts/alert_worker.py
+++ b/alerts/alert_worker.py
@@ -5,6 +5,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
+# Alert Worker to listen for alerts and call python plugins
+# for user-controlled reaction to alerts.
 
 import json
 import os

--- a/alerts/alert_worker.py
+++ b/alerts/alert_worker.py
@@ -5,12 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
-#
-# Alert Worker to listen for alerts and call python plugins
-# for user-controlled reaction to alerts.
 
 import json
 import os

--- a/alerts/amo_failed_logins.py
+++ b/alerts/amo_failed_logins.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, PhraseMatch

--- a/alerts/auditd_sftp.py
+++ b/alerts/auditd_sftp.py
@@ -5,12 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
-# Aaron Meihm ameihm@mozilla.com
-# Michal Purzynski <mpurzynski@mozilla.com>
-# Alicia Smith <asmith@mozilla.com>
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch

--- a/alerts/bruteforce_ssh.py
+++ b/alerts/bruteforce_ssh.py
@@ -5,10 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch, TermsMatch

--- a/alerts/bugzilla_auth_bruteforce.py
+++ b/alerts/bugzilla_auth_bruteforce.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski michal@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, PhraseMatch

--- a/alerts/cloudtrail_deadman.py
+++ b/alerts/cloudtrail_deadman.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from lib.alerttask import AlertTask

--- a/alerts/cloudtrail_logging_disabled.py
+++ b/alerts/cloudtrail_logging_disabled.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch

--- a/alerts/confluence_shell.py
+++ b/alerts/confluence_shell.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jonathan Claudius jclaudius@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, QueryStringMatch

--- a/alerts/correlated_alerts.py
+++ b/alerts/correlated_alerts.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski michal@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, PhraseMatch

--- a/alerts/deadman.py
+++ b/alerts/deadman.py
@@ -5,6 +5,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
+# a collection of alerts looking for the lack of events
+# to alert on a dead input source.
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch

--- a/alerts/deadman.py
+++ b/alerts/deadman.py
@@ -5,12 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
-#
-# a collection of alerts looking for the lack of events
-# to alert on a dead input source.
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch

--- a/alerts/duo_authfail.py
+++ b/alerts/duo_authfail.py
@@ -3,13 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
-# Aaron Meihm ameihm@mozilla.com
-# Michal Purzynski <mpurzynski@mozilla.com>
-# Alicia Smith <asmith@mozilla.com>
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, PhraseMatch

--- a/alerts/duo_fail_open.py
+++ b/alerts/duo_fail_open.py
@@ -5,6 +5,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
+# This script alerts when openvpn's duo security failed to contact the duo server and let the user in.
+# This is a very serious warning that must be acted upon as it means MFA failed and only one factor was validated (in
+# this case a VPN certificate)
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, PhraseMatch

--- a/alerts/duo_fail_open.py
+++ b/alerts/duo_fail_open.py
@@ -5,12 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# kang@mozilla.com
-#
-# This script alerts when openvpn's duo security failed to contact the duo server and let the user in.
-# This is a very serious warning that must be acted upon as it means MFA failed and only one factor was validated (in
-# this case a VPN certificate)
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, PhraseMatch

--- a/alerts/fxa_alerts.py
+++ b/alerts/fxa_alerts.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch, WildcardMatch

--- a/alerts/generic_alert_loader.py
+++ b/alerts/generic_alert_loader.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# kang@mozilla.com
-# bmyers@mozilla.com
 
 # TODO: Dont use query_models, nicer fixes for AlertTask
 

--- a/alerts/geomodel.py
+++ b/alerts/geomodel.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2015 Mozilla Corporation
 #
-# Contributors:
-# Aaron Meihm <ameihm@mozilla.com>
-# Brandon Myers <bmyers@mozilla.com>
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch

--- a/alerts/host_scanner_alerts.py
+++ b/alerts/host_scanner_alerts.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, PhraseMatch

--- a/alerts/http_auth_bruteforce.py
+++ b/alerts/http_auth_bruteforce.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski michal@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, PhraseMatch

--- a/alerts/http_errors.py
+++ b/alerts/http_errors.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski michal@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, PhraseMatch

--- a/alerts/ldap_add.py
+++ b/alerts/ldap_add.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch

--- a/alerts/ldap_delete.py
+++ b/alerts/ldap_delete.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch

--- a/alerts/ldap_group.py
+++ b/alerts/ldap_group.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch

--- a/alerts/ldap_lockout.py
+++ b/alerts/ldap_lockout.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch

--- a/alerts/lib/alerttask.py
+++ b/alerts/lib/alerttask.py
@@ -5,10 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 import collections
 import json

--- a/alerts/lib/config.py
+++ b/alerts/lib/config.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
 
 from celery.schedules import crontab, timedelta
 import time

--- a/alerts/multiple_intel_hits.py
+++ b/alerts/multiple_intel_hits.py
@@ -5,10 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
-# Michal Purzynski <mpurzynski@mozilla.com>
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, TermsMatch

--- a/alerts/old_events.py
+++ b/alerts/old_events.py
@@ -5,11 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
-#
-# Looks for events that have an old timestamp
-# which could mean theres something wrong in the event pipeline
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, LessThanMatch

--- a/alerts/old_events.py
+++ b/alerts/old_events.py
@@ -5,6 +5,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
+# Looks for events that have an old timestamp
+# which could mean theres something wrong in the event pipeline
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, LessThanMatch

--- a/alerts/open_port_violation.py
+++ b/alerts/open_port_violation.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Jonathan Claudius jclaudius@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch

--- a/alerts/plugins/dashboard_geomodel.py
+++ b/alerts/plugins/dashboard_geomodel.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import hjson
 import os

--- a/alerts/plugins/pagerDutyTriggerEvent.py
+++ b/alerts/plugins/pagerDutyTriggerEvent.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import requests
 import json

--- a/alerts/promisc_audit.py
+++ b/alerts/promisc_audit.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
+# This code alerts on every successfully opened session on any of the host from a given list
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, QueryStringMatch, PhraseMatch

--- a/alerts/promisc_audit.py
+++ b/alerts/promisc_audit.py
@@ -5,10 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
-#
-# This code alerts on every successfully opened session on any of the host from a given list
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, QueryStringMatch, PhraseMatch

--- a/alerts/promisc_kernel.py
+++ b/alerts/promisc_kernel.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
+# This code alerts on every successfully opened session on any of the host from a given list
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, QueryStringMatch, PhraseMatch

--- a/alerts/promisc_kernel.py
+++ b/alerts/promisc_kernel.py
@@ -5,10 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
-#
-# This code alerts on every successfully opened session on any of the host from a given list
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, QueryStringMatch, PhraseMatch

--- a/alerts/proxy_drop.py
+++ b/alerts/proxy_drop.py
@@ -5,10 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jonathan Claudius jclaudius@mozilla.com
-# Brandon Myers bmyers@mozilla.com
-# Alicia Smith asmith@mozilla.com
 
 
 from lib.alerttask import AlertTask

--- a/alerts/session_opened_sensitive_user.py
+++ b/alerts/session_opened_sensitive_user.py
@@ -5,10 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
-#
-# This code alerts on every successfully opened session for any user in the list
 
 import datetime
 from lib.alerttask import AlertTask

--- a/alerts/session_opened_sensitive_user.py
+++ b/alerts/session_opened_sensitive_user.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
+# This code alerts on every successfully opened session for any user in the list
 
 import datetime
 from lib.alerttask import AlertTask

--- a/alerts/sqs_queues_deadman.py
+++ b/alerts/sqs_queues_deadman.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch

--- a/alerts/ssh_access_signreleng.py
+++ b/alerts/ssh_access_signreleng.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Aaron Meihm <ameihm@mozilla.com>
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch, QueryStringMatch

--- a/alerts/ssh_bruteforce_bro.py
+++ b/alerts/ssh_bruteforce_bro.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski michal@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch, PhraseMatch

--- a/alerts/ssh_ioc.py
+++ b/alerts/ssh_ioc.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2015 Mozilla Corporation
 #
-# Contributors:
-# Aaron Meihm <ameihm@mozilla.com>
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch

--- a/alerts/ssh_key.py
+++ b/alerts/ssh_key.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Aaron Meihm <ameihm@mozilla.com>
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch

--- a/alerts/ssh_lateral.py
+++ b/alerts/ssh_lateral.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Aaron Meihm <ameihm@mozilla.com>
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, QueryStringMatch, PhraseMatch

--- a/alerts/ssl_blacklist_hit.py
+++ b/alerts/ssl_blacklist_hit.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski michal@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, ExistsMatch

--- a/alerts/unauth_ssh.py
+++ b/alerts/unauth_ssh.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2015 Mozilla Corporation
 #
-# Contributors:
-# Aaron Meihm <ameihm@mozilla.com>
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, QueryStringMatch, PhraseMatch

--- a/alerts/vpn_duo_auth_failures.py
+++ b/alerts/vpn_duo_auth_failures.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
 
 from lib.alerttask import AlertTask
 from query_models import SearchQuery, TermMatch, PhraseMatch

--- a/benchmarking/workers/json2Mozdef.py
+++ b/benchmarking/workers/json2Mozdef.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import os
 import sys

--- a/bot/modules/roulette.py
+++ b/bot/modules/roulette.py
@@ -4,6 +4,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
+# Copy of https://github.com/gdestuynder/Stupid-python-bot/blob/master/modules/roulette.py
+# ported to kitnirc
 
 
 import logging

--- a/bot/modules/roulette.py
+++ b/bot/modules/roulette.py
@@ -4,11 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-#
-# Copy of https://github.com/gdestuynder/Stupid-python-bot/blob/master/modules/roulette.py
-# ported to kitnirc
 
 
 import logging

--- a/bot/modules/zilla.py
+++ b/bot/modules/zilla.py
@@ -6,9 +6,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# kang@mozilla.com
-#
 
 import logging
 from kitnirc.client import Channel

--- a/bot/mozdefbot.py
+++ b/bot/mozdefbot.py
@@ -4,8 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 """mozdef bot using KitnIRC."""
 import json

--- a/bot/mozdefbot_slack.py
+++ b/bot/mozdefbot_slack.py
@@ -4,8 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 """ mozdef bot using slack
     to install - 'pip install slackclient'

--- a/cron/backupSnapshot.py
+++ b/cron/backupSnapshot.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
 
 # Snapshot configured backups
 # Meant to be run once/day

--- a/cron/backupSnapshot.sh
+++ b/cron/backupSnapshot.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/backupSnapshot.py -c /opt/mozdef/envs/mozdef/cron/backup.conf

--- a/cron/collectAttackers.py
+++ b/cron/collectAttackers.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 import collections
 import json

--- a/cron/collectAttackers.sh
+++ b/cron/collectAttackers.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/collectAttackers.py -c /opt/mozdef/envs/mozdef/cron/collectAttackers.conf

--- a/cron/collectSSHFingerprints.py
+++ b/cron/collectSSHFingerprints.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import logging
 import random

--- a/cron/collectSSHFingerprints.sh
+++ b/cron/collectSSHFingerprints.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/collectSSHFingerprints.py -c /opt/mozdef/envs/mozdef/cron/collectSSHFingerprints.conf

--- a/cron/correlateUserMacAddress.py
+++ b/cron/correlateUserMacAddress.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import json
 import logging

--- a/cron/correlateUserMacAddress.sh
+++ b/cron/correlateUserMacAddress.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/correlateUserMacAddress.py -c /opt/mozdef/envs/mozdef/cron/correlateUserMacAddress.conf

--- a/cron/createIPBlockList.py
+++ b/cron/createIPBlockList.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import boto
 import boto.s3

--- a/cron/createIPBlockList.sh
+++ b/cron/createIPBlockList.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/createIPBlockList.py -c /opt/mozdef/envs/mozdef/cron/createIPBlockList.conf

--- a/cron/duo_logpull.py
+++ b/cron/duo_logpull.py
@@ -3,9 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Contributors:
-# Guillaume Destuynder kang@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 import sys
 import os

--- a/cron/esMaint.sh
+++ b/cron/esMaint.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/rotateIndexes.py -c /opt/mozdef/envs/mozdef/cron/backup.conf

--- a/cron/eventStats.py
+++ b/cron/eventStats.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import json
 import logging

--- a/cron/eventStats.sh
+++ b/cron/eventStats.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/eventStats.py -c /opt/mozdef/envs/mozdef/cron/eventStats.conf

--- a/cron/google2mozdef.py
+++ b/cron/google2mozdef.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import os
 import sys

--- a/cron/google2mozdef.sh
+++ b/cron/google2mozdef.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/google2mozdef.py -c /opt/mozdef/envs/mozdef/cron/google2mozdef.conf

--- a/cron/healthAndStatus-fxa.sh
+++ b/cron/healthAndStatus-fxa.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/healthAndStatus.py -c /opt/mozdef/envs/mozdef/cron/healthAndStatus.fxa.conf

--- a/cron/healthAndStatus.py
+++ b/cron/healthAndStatus.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Anthony Verez averez@mozilla.com
 
 import json
 import logging

--- a/cron/healthAndStatus.sh
+++ b/cron/healthAndStatus.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/healthAndStatus.py -c /opt/mozdef/envs/mozdef/cron/healthAndStatus.conf

--- a/cron/healthToMongo.py
+++ b/cron/healthToMongo.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 import logging
 import requests

--- a/cron/healthToMongo.sh
+++ b/cron/healthToMongo.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/healthToMongo.py -c /opt/mozdef/envs/mozdef/cron/healthToMongo.conf

--- a/cron/import_threat_exchange.py
+++ b/cron/import_threat_exchange.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import os
 import sys

--- a/cron/import_threat_exchange.sh
+++ b/cron/import_threat_exchange.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/import_threat_exchange.py -c /opt/mozdef/envs/mozdef/cron/import_threat_exchange.conf

--- a/cron/okta2mozdef.py
+++ b/cron/okta2mozdef.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import os
 import sys

--- a/cron/okta2mozdef.sh
+++ b/cron/okta2mozdef.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/okta2mozdef.py -c /opt/mozdef/envs/mozdef/cron/okta2mozdef.conf

--- a/cron/pruneES.sh
+++ b/cron/pruneES.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/pruneIndexes.py -c /opt/mozdef/envs/mozdef/cron/backup.conf

--- a/cron/pruneIndexes.py
+++ b/cron/pruneIndexes.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Anthony Verez averez@mozilla.com
 
 # set this to run as a cronjob (after backup has completed)
 # to regularly remove indexes

--- a/cron/rotateIndexes.py
+++ b/cron/rotateIndexes.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Anthony Verez averez@mozilla.com
 
 # set this to run as a cronjob at 00:00 UTC to create the indexes
 # necessary for mozdef

--- a/cron/setupIndexTemplates.py
+++ b/cron/setupIndexTemplates.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Anthony Verez averez@mozilla.com
 
 # Use this to setup the index templates for mozdef
 # You only need to run it once, it will setup the templates

--- a/cron/syncAlertsToMongo.py
+++ b/cron/syncAlertsToMongo.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import calendar
 import logging

--- a/cron/syncAlertsToMongo.sh
+++ b/cron/syncAlertsToMongo.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.py -c /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.conf

--- a/cron/update_generic_alerts.py
+++ b/cron/update_generic_alerts.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 from git import Repo, cmd
 

--- a/cron/update_generic_alerts.sh
+++ b/cron/update_generic_alerts.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/update_generic_alerts.py -c /opt/mozdef/envs/mozdef/cron/update_generic_alerts.conf

--- a/cron/update_geolite_db.py
+++ b/cron/update_geolite_db.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import sys
 import os

--- a/cron/update_geolite_db.sh
+++ b/cron/update_geolite_db.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/update_geolite_db.py -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.conf

--- a/cron/update_ip_list.py
+++ b/cron/update_ip_list.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import sys
 import os

--- a/cron/update_ip_list.sh
+++ b/cron/update_ip_list.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/update_ip_list.py -c /opt/mozdef/envs/mozdef/cron/update_ip_list.conf

--- a/cron/verify_event_fields.py
+++ b/cron/verify_event_fields.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import sys
 import os

--- a/cron/verify_event_fields.sh
+++ b/cron/verify_event_fields.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/verify_event_fields.py -c /opt/mozdef/envs/mozdef/cron/verify_event_fields.conf

--- a/cron/vidyo2MozDef.py
+++ b/cron/vidyo2MozDef.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-# Contributor: gdestuynder@mozilla.com
-# Contributor: jbryner@mozilla.com
-
 import copy
 import os
 import sys

--- a/cron/vidyo2MozDef.sh
+++ b/cron/vidyo2MozDef.sh
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 source  /opt/mozdef/envs/mozdef/bin/activate
 /opt/mozdef/envs/mozdef/cron/vidyo2MozDef.py -c /opt/mozdef/envs/mozdef/cron/vidyo2MozDef.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,12 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Yohann Lepage yohann@lepage.info
-# Anthony Verez averez@mozilla.com
-# Charlie Lewis clewis@iqt.org
-# Brandon Myers bmyers@mozilla.com
 
 FROM centos:7
 

--- a/docker/compose/mozdef_alerts/files/config.py
+++ b/docker/compose/mozdef_alerts/files/config.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 from celery.schedules import crontab, timedelta
 import time

--- a/docker/conf/config.py
+++ b/docker/conf/config.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 from celery.schedules import crontab, timedelta
 import time

--- a/docker/conf/initial_setup.py
+++ b/docker/conf/initial_setup.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import argparse
 

--- a/examples/demo/json2MQ.py
+++ b/examples/demo/json2MQ.py
@@ -5,6 +5,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
+# Simple sample code to generate an event and deposit as json on rabbitmq
+
 
 import os
 import pytz

--- a/examples/demo/json2MQ.py
+++ b/examples/demo/json2MQ.py
@@ -5,12 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
-#
-# Simple sample code to generate an event and deposit as json on rabbitmq
-#
 
 import os
 import pytz

--- a/examples/demo/sampleData2MozDef.py
+++ b/examples/demo/sampleData2MozDef.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import os
 import sys

--- a/examples/es-docs/inject.py
+++ b/examples/es-docs/inject.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 import os
 import sys

--- a/examples/plugins/dummy_id.py
+++ b/examples/plugins/dummy_id.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 
 class message(object):

--- a/lib/query_models/aggregated_results.py
+++ b/lib/query_models/aggregated_results.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 def AggregatedResults(input_results):

--- a/lib/query_models/aggregation.py
+++ b/lib/query_models/aggregation.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import A

--- a/lib/query_models/boolean_match.py
+++ b/lib/query_models/boolean_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/exists_match.py
+++ b/lib/query_models/exists_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/less_than_match.py
+++ b/lib/query_models/less_than_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/missing_match.py
+++ b/lib/query_models/missing_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/phrase_match.py
+++ b/lib/query_models/phrase_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/query_string_match.py
+++ b/lib/query_models/query_string_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/range_match.py
+++ b/lib/query_models/range_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/search_query.py
+++ b/lib/query_models/search_query.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from utilities.toUTC import toUTC

--- a/lib/query_models/simple_results.py
+++ b/lib/query_models/simple_results.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 def SimpleResults(input_results):

--- a/lib/query_models/term_match.py
+++ b/lib/query_models/term_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/terms_match.py
+++ b/lib/query_models/terms_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/query_models/wildcard_match.py
+++ b/lib/query_models/wildcard_match.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 from elasticsearch_dsl import Q

--- a/lib/utilities/dot_dict.py
+++ b/lib/utilities/dot_dict.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Guillaume Destuynder kang@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 
 class DotDict(dict):

--- a/lib/utilities/logger.py
+++ b/lib/utilities/logger.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import logging
 import sys

--- a/loginput/index.py
+++ b/loginput/index.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 import os
 import sys

--- a/mq/esworker_cloudtrail.py
+++ b/mq/esworker_cloudtrail.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 import json

--- a/mq/esworker_eventtask.py
+++ b/mq/esworker_eventtask.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Anthony Verez averez@mozilla.com
 
 
 import json

--- a/mq/esworker_papertrail.py
+++ b/mq/esworker_papertrail.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2015 Mozilla Corporation
 #
-# Contributors:
-# Aaron Meihm ameihm@mozilla.com
 
 # Reads from papertrail using the API and inserts log data into ES in
 # the same manner as esworker_eventtask.py

--- a/mq/esworker_sns_sqs.py
+++ b/mq/esworker_sns_sqs.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 import json

--- a/mq/esworker_sqs.py
+++ b/mq/esworker_sqs.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 # kombu's support for SQS is buggy
 # so this version uses boto

--- a/mq/lib/plugins.py
+++ b/mq/lib/plugins.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 import sys

--- a/mq/plugins/auditdFixup.py
+++ b/mq/plugins/auditdFixup.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 
 class message(object):

--- a/mq/plugins/broFixup.py
+++ b/mq/plugins/broFixup.py
@@ -3,10 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
-# Michal Purzynski mpurzynski@mozilla.com
 
 import netaddr
 from utilities.toUTC import toUTC

--- a/mq/plugins/complianceitems.py
+++ b/mq/plugins/complianceitems.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Julien Vehent jvehent@mozilla.com
-# Aaron Meihm   ameihm@mozilla.com
 
 import hashlib
 import sys

--- a/mq/plugins/customDocType.py
+++ b/mq/plugins/customDocType.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 
 class message(object):

--- a/mq/plugins/dropMessage.py
+++ b/mq/plugins/dropMessage.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 
 class message(object):

--- a/mq/plugins/filterlog.py
+++ b/mq/plugins/filterlog.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/mq/plugins/fluentdSqsFixup.py
+++ b/mq/plugins/fluentdSqsFixup.py
@@ -5,9 +5,6 @@
 #
 # This script copies the format/handling mechanism of ipFixup.py (git f5734b0c7e412424b44a6d7af149de6250fc70a2)
 #
-# Contributors:
-# Guillaume Destuynder kang@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
 
 import netaddr
 import sys

--- a/mq/plugins/fxaFixup.py
+++ b/mq/plugins/fxaFixup.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 import netaddr
 

--- a/mq/plugins/geoip.py
+++ b/mq/plugins/geoip.py
@@ -3,9 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 import netaddr
 import os

--- a/mq/plugins/googleFixup.py
+++ b/mq/plugins/googleFixup.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 
 class message(object):

--- a/mq/plugins/ipFixup.py
+++ b/mq/plugins/ipFixup.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import netaddr
 

--- a/mq/plugins/mozilla_location.py
+++ b/mq/plugins/mozilla_location.py
@@ -3,10 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Arzhel Younsi arzhel@mozilla.com
-# Jeff Bryner jbryner@mozilla.com
-# Brandon Myers bmyers@mozilla.com
 
 import os
 from configlib import getConfig

--- a/mq/plugins/nagioshostname.py
+++ b/mq/plugins/nagioshostname.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Eric Ziegenhorn eziegenhorn@mozilla.com
 
 import hashlib
 class message(object):

--- a/mq/plugins/netflowFixup.py
+++ b/mq/plugins/netflowFixup.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 
 class message(object):

--- a/mq/plugins/observium.py
+++ b/mq/plugins/observium.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Arzhel Younsi arzhel@mozilla.com
 
 import re
 

--- a/mq/plugins/parse_sshd.py
+++ b/mq/plugins/parse_sshd.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
 
 import sys
 import os

--- a/mq/plugins/parse_su.py
+++ b/mq/plugins/parse_su.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
 
 import sys
 import os

--- a/mq/plugins/rt_flow.py
+++ b/mq/plugins/rt_flow.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 import re
 

--- a/mq/plugins/snmptt.py
+++ b/mq/plugins/snmptt.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 import re
 

--- a/mq/plugins/sshdFindIP.py
+++ b/mq/plugins/sshdFindIP.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import netaddr
 

--- a/mq/plugins/ttl_auditd.py
+++ b/mq/plugins/ttl_auditd.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Anthony Verez averez@mozilla.com
 
 
 class message(object):

--- a/mq/plugins/vidyoCallID.py
+++ b/mq/plugins/vidyoCallID.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import hashlib
 class message(object):

--- a/mq/plugins/vulnerability.py
+++ b/mq/plugins/vulnerability.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2015 Mozilla Corporation
 #
-# Contributors:
-# Aaron Meihm ameihm@mozilla.com
 
 import hashlib
 import sys

--- a/rest/index.py
+++ b/rest/index.py
@@ -3,11 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
-# Anthony Verez averez@mozilla.com
-# Yash Mehrotra yashmehrotra95@gmail.com
-# Brandon Myers bmyers@mozilla.com
 
 import bottle
 import json

--- a/rest/plugins/banhammer.py
+++ b/rest/plugins/banhammer.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import os
 import sys

--- a/rest/plugins/cymon.py
+++ b/rest/plugins/cymon.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import requests
 import json

--- a/rest/plugins/facebook_threatexchange.py
+++ b/rest/plugins/facebook_threatexchange.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Jeff Bryner jbryner@mozilla.com
 
 import os
 import sys

--- a/rest/plugins/vpc_blackhole.py
+++ b/rest/plugins/vpc_blackhole.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
 
 import os
 import sys

--- a/tests/alerts/alert_test_suite.py
+++ b/tests/alerts/alert_test_suite.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# bmyers@mozilla.com
 
 import os.path
 import sys

--- a/tests/alerts/test_bruteforce_ssh.py
+++ b/tests/alerts/test_bruteforce_ssh.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 from positive_alert_test_case import PositiveAlertTestCase
 from negative_alert_test_case import NegativeAlertTestCase

--- a/tests/alerts/test_duo_authfail.py
+++ b/tests/alerts/test_duo_authfail.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 from positive_alert_test_case import PositiveAlertTestCase
 from negative_alert_test_case import NegativeAlertTestCase

--- a/tests/alerts/test_geomodel.py
+++ b/tests/alerts/test_geomodel.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 from positive_alert_test_case import PositiveAlertTestCase
 from negative_alert_test_case import NegativeAlertTestCase

--- a/tests/alerts/test_open_port_violation.py
+++ b/tests/alerts/test_open_port_violation.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 from positive_alert_test_case import PositiveAlertTestCase
 from negative_alert_test_case import NegativeAlertTestCase

--- a/tests/alerts/test_session_opened_sensitive_user.py
+++ b/tests/alerts/test_session_opened_sensitive_user.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
 
 from positive_alert_test_case import PositiveAlertTestCase
 from negative_alert_test_case import NegativeAlertTestCase

--- a/tests/alerts/test_sqs_queues_deadman.py
+++ b/tests/alerts/test_sqs_queues_deadman.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# bmyers@mozilla.com
 
 from positive_alert_test_case import PositiveAlertTestCase
 from negative_alert_test_case import NegativeAlertTestCase

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
-#
+
+import time
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
-import time
 
 
 def pytest_addoption(parser):

--- a/tests/lib/query_models/query_test_suite.py
+++ b/tests/lib/query_models/query_test_suite.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import os
 import sys

--- a/tests/lib/query_models/test_aggregation.py
+++ b/tests/lib/query_models/test_aggregation.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import os
 import sys

--- a/tests/lib/test_elasticsearch_client.py
+++ b/tests/lib/test_elasticsearch_client.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import os
 import sys

--- a/tests/lib/test_plugins/plugin1.py
+++ b/tests/lib/test_plugins/plugin1.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/tests/lib/test_plugins/plugin2.py
+++ b/tests/lib/test_plugins/plugin2.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/tests/lib/test_plugins/plugin3.py
+++ b/tests/lib/test_plugins/plugin3.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/tests/lib/test_plugins/plugin4.py
+++ b/tests/lib/test_plugins/plugin4.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/tests/lib/test_plugins/plugin5.py
+++ b/tests/lib/test_plugins/plugin5.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/tests/lib/test_plugins/plugin6.py
+++ b/tests/lib/test_plugins/plugin6.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/tests/lib/test_plugins/plugin7.py
+++ b/tests/lib/test_plugins/plugin7.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/tests/lib/test_plugins/plugin8.py
+++ b/tests/lib/test_plugins/plugin8.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 class message(object):

--- a/tests/lib/utilities/test_dot_dict.py
+++ b/tests/lib/utilities/test_dot_dict.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 import pytest

--- a/tests/mq/plugins/test_filterlog.py
+++ b/tests/mq/plugins/test_filterlog.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import os
 import sys

--- a/tests/mq/plugins/test_parse_sshd.py
+++ b/tests/mq/plugins/test_parse_sshd.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
 
 import os
 import sys

--- a/tests/mq/plugins/test_parse_su.py
+++ b/tests/mq/plugins/test_parse_su.py
@@ -3,8 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Michal Purzynski mpurzynski@mozilla.com
 
 import os
 import sys

--- a/tests/mq/test_esworker_eventtask.py
+++ b/tests/mq/test_esworker_eventtask.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 import pytz
 import tzlocal

--- a/tests/mq/test_esworker_sns_sqs.py
+++ b/tests/mq/test_esworker_sns_sqs.py
@@ -5,8 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 import os

--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -5,9 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 #
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
-# Alicia Smith asmith@mozilla.com
 
 
 import os

--- a/tests/unit_test_suite.py
+++ b/tests/unit_test_suite.py
@@ -4,9 +4,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
-#
-# Contributors:
-# Brandon Myers bmyers@mozilla.com
 
 
 import os


### PR DESCRIPTION
I used the following script to make the changes.

```
In [2]: for f in all_files:
   ...:     fp = open(f, 'r+')
   ...:     text = re.sub(r'(?s)(# Contributors:.*?)(?:(?:\r*\n){2})', '\n', fp.read())
   ...:     fp.seek(0)
   ...:     fp.truncate()
   ...:     fp.write(text)
```