### PR TITLE
Lock alert tests into specific datetime

### DIFF
--- a/tests/alerts/alert_test_suite.py
+++ b/tests/alerts/alert_test_suite.py
@@ -100,7 +100,7 @@ class AlertTestSuite(UnitTestSuite):
                 target[k] = v
         return target
 
-    @freeze_time("2017-01-01 01:00:00")
+    @freeze_time("2017-01-01 01:00:00", tz_offset=0)
     def test_alert_test_case(self, test_case):
         self.verify_starting_values(test_case)
         if test_case.expected_test_result is True:

--- a/tests/alerts/alert_test_suite.py
+++ b/tests/alerts/alert_test_suite.py
@@ -15,6 +15,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 
 from unit_test_suite import UnitTestSuite
 
+from freezegun import freeze_time
+
 import copy
 import re
 import json
@@ -98,6 +100,7 @@ class AlertTestSuite(UnitTestSuite):
                 target[k] = v
         return target
 
+    @freeze_time("2017-01-01 01:00:00")
     def test_alert_test_case(self, test_case):
         self.verify_starting_values(test_case)
         if test_case.expected_test_result is True:

--- a/tests/requirements_tests.txt
+++ b/tests/requirements_tests.txt
@@ -1,3 +1,4 @@
 pytest==3.1.1
 mock==2.0.0
 WebTest==2.0.27
+freezegun==0.3.9


### PR DESCRIPTION
This locks the datetime in alert tests, so that we have more of a controlled environment.