### PR TITLE
Adding old garbage collection stats to About page.

### DIFF
--- a/cron/healthToMongo.py
+++ b/cron/healthToMongo.py
@@ -79,20 +79,22 @@ def getEsNodesStats():
     jsonobj = r.json()
     results = []
     for nodeid in jsonobj['nodes']:
-        # Skip non masters and data nodes since it won't have full stats
+        # Skip non masters and non data nodes since it won't have full stats
         if ('attributes' in jsonobj['nodes'][nodeid] and
                 jsonobj['nodes'][nodeid]['attributes']['master'] == 'false' and
                 jsonobj['nodes'][nodeid]['attributes']['data'] == 'false'):
             continue
-
+t
         results.append({
             'hostname': jsonobj['nodes'][nodeid]['host'],
             'disk_free': jsonobj['nodes'][nodeid]['fs']['total']['free_in_bytes'] / (1024 * 1024 * 1024),
             'disk_total': jsonobj['nodes'][nodeid]['fs']['total']['total_in_bytes'] / (1024 * 1024 * 1024),
             'mem_heap_per': jsonobj['nodes'][nodeid]['jvm']['mem']['heap_used_percent'],
+            'gc_old': jsonobj['nodes'][nodeid]['jvm']['gc']['collectors']['old']['collection_time_in_millis'] / 1000,
             'cpu_usage': jsonobj['nodes'][nodeid]['os']['cpu_percent'],
             'load': jsonobj['nodes'][nodeid]['os']['load_average']
         })
+    print(results)
     return results
 
 

--- a/meteor/app/client/mozdefhealth.html
+++ b/meteor/app/client/mozdefhealth.html
@@ -70,6 +70,7 @@ Anthony Verez averez@mozilla.com
                 <td>CPU %</td>
                 <td>Load Average</td>
                 <td>JVM Memory %</td>
+                <td>GC Old (s)</td>
                 <td>Disk Free (GB)</td>
                 <td>Disk Total (GB)</td>
             </tr>
@@ -111,6 +112,7 @@ Anthony Verez averez@mozilla.com
         <td>{{cpu_usage}}</td>
         <td>{{load}}</td>
         <td>{{mem_heap_per}}</td>
+        <td>{{gc_old}}</td>
         <td>{{disk_free}}</td>
         <td>{{disk_total}}</td>
     </tr>


### PR DESCRIPTION
Old GC times are crucial to a healthy JVM - adding this stat so we can be aware when gc is going over recommended times. This can also alert us to high volume shards which may indicate a need to add additional shards.