### PR TITLE
Modify workers to use logger

### DIFF
--- a/lib/elasticsearch_client.py
+++ b/lib/elasticsearch_client.py
@@ -8,7 +8,8 @@ from elasticsearch.helpers import bulk, BulkIndexError
 from query_models import SearchQuery, TermMatch, AggregatedResults, SimpleResults
 from bulk_queue import BulkQueue
 
-from utilities.logger import logger, initLogger
+from utilities.logger import logger
+
 from event import Event
 
 
@@ -36,7 +37,6 @@ class ElasticsearchClient():
         self.es_connection = Elasticsearch(servers)
         self.es_connection.ping()
         self.bulk_queue = BulkQueue(self, threshold=bulk_amount, flush_time=bulk_refresh_time)
-        initLogger()
 
     def delete_index(self, index_name, ignore_fail=False):
         ignore_codes = []

--- a/lib/utilities/is_cef.py
+++ b/lib/utilities/is_cef.py
@@ -1,0 +1,16 @@
+def isCEF(aDict):
+    # determine if this is a CEF event
+    # could be an event posted to the /cef http endpoint
+    if 'endpoint' in aDict.keys() and aDict['endpoint'] == 'cef':
+        return True
+    # maybe it snuck in some other way
+    # check some key CEF indicators (the header fields)
+    if 'fields' in aDict.keys() and isinstance(aDict['fields'], dict):
+        lowerKeys = [s.lower() for s in aDict['fields'].keys()]
+        if 'devicevendor' in lowerKeys and 'deviceproduct' in lowerKeys and 'deviceversion' in lowerKeys:
+            return True
+    if 'details' in aDict.keys() and isinstance(aDict['details'], dict):
+        lowerKeys = [s.lower() for s in aDict['details'].keys()]
+        if 'devicevendor' in lowerKeys and 'deviceproduct' in lowerKeys and 'deviceversion' in lowerKeys:
+            return True
+    return False

--- a/lib/utilities/logger.py
+++ b/lib/utilities/logger.py
@@ -12,8 +12,6 @@ from logging.handlers import SysLogHandler
 
 from toUTC import toUTC
 
-logger = logging.getLogger(sys.argv[0])
-
 
 def loggerTimeStamp(self, record, datefmt=None):
     return toUTC(datetime.now()).isoformat()
@@ -30,9 +28,16 @@ def initLogger(options=None):
     except Exception:
         output = 'stderr'
 
+    for handler in logger.handlers:
+        logger.removeHandler(handler)
+
     if output == 'syslog':
         logger.addHandler(SysLogHandler(address=(options.sysloghostname, options.syslogport)))
     else:
         sh = logging.StreamHandler(sys.stderr)
         sh.setFormatter(formatter)
         logger.addHandler(sh)
+
+
+logger = logging.getLogger(sys.argv[0])
+initLogger()

--- a/lib/utilities/remove_at.py
+++ b/lib/utilities/remove_at.py
@@ -1,0 +1,3 @@
+def removeAt(astring):
+    '''remove the leading @ from a string'''
+    return astring.replace('@', '')

--- a/lib/utilities/to_unicode.py
+++ b/lib/utilities/to_unicode.py
@@ -1,0 +1,8 @@
+def toUnicode(obj, encoding='utf-8'):
+    if type(obj) in [int, long, float, complex]:
+        # likely a number, convert it to string to get to unicode
+        obj = str(obj)
+    if isinstance(obj, basestring):
+        if not isinstance(obj, unicode):
+            obj = unicode(obj, encoding)
+    return obj

--- a/mq/esworker_eventtask.py
+++ b/mq/esworker_eventtask.py
@@ -8,22 +8,23 @@
 
 import json
 import kombu
-import math
 import os
-import pynsive
 import sys
 import socket
 from configlib import getConfig, OptionParser
-from datetime import datetime, timedelta
-from operator import itemgetter
+from datetime import datetime
 from kombu import Connection, Queue, Exchange
 from kombu.mixins import ConsumerMixin
 
-import os
 sys.path.append(os.path.join(os.path.dirname(__file__), "../lib"))
 from elasticsearch_client import ElasticsearchClient, ElasticsearchBadServer, ElasticsearchInvalidIndex, ElasticsearchException
 
 from utilities.toUTC import toUTC
+from utilities.to_unicode import toUnicode
+from utilities.remove_at import removeAt
+from utilities.is_cef import isCEF
+
+from lib.plugins import sendEventToPlugins, registerPlugins
 
 
 # running under uwsgi?
@@ -32,39 +33,6 @@ try:
     hasUWSGI = True
 except ImportError as e:
     hasUWSGI = False
-
-
-def removeAt(astring):
-    '''remove the leading @ from a string'''
-    return astring.replace('@', '')
-
-
-def isCEF(aDict):
-    # determine if this is a CEF event
-    # could be an event posted to the /cef http endpoint
-    if 'endpoint' in aDict.keys() and aDict['endpoint'] == 'cef':
-        return True
-    # maybe it snuck in some other way
-    # check some key CEF indicators (the header fields)
-    if 'fields' in aDict.keys() and isinstance(aDict['fields'], dict):
-        lowerKeys = [s.lower() for s in aDict['fields'].keys()]
-        if 'devicevendor' in lowerKeys and 'deviceproduct' in lowerKeys and 'deviceversion' in lowerKeys:
-            return True
-    if 'details' in aDict.keys() and isinstance(aDict['details'], dict):
-        lowerKeys = [s.lower() for s in aDict['details'].keys()]
-        if 'devicevendor' in lowerKeys and 'deviceproduct' in lowerKeys and 'deviceversion' in lowerKeys:
-            return True
-    return False
-
-
-def toUnicode(obj, encoding='utf-8'):
-    if type(obj) in [int, long, float, complex]:
-        # likely a number, convert it to string to get to unicode
-        obj = str(obj)
-    if isinstance(obj, basestring):
-        if not isinstance(obj, unicode):
-            obj = unicode(obj, encoding)
-    return obj
 
 
 def keyMapping(aDict):
@@ -313,149 +281,6 @@ class taskConsumer(ConsumerMixin):
             sys.stderr.write("esworker exception in events queue %r\n" % e)
 
 
-def registerPlugins():
-    pluginList = list()   # tuple of module,registration dict,priority
-    plugin_manager = pynsive.PluginManager()
-    if os.path.exists('plugins'):
-        modules = pynsive.list_modules('plugins')
-        for mname in modules:
-            module = pynsive.import_module(mname)
-            reload(module)
-            if not module:
-                raise ImportError('Unable to load module {}'.format(mname))
-            else:
-                if 'message' in dir(module):
-                    mclass = module.message()
-                    mreg = mclass.registration
-                    if 'priority' in dir(mclass):
-                        mpriority = mclass.priority
-                    else:
-                        mpriority = 100
-                    if isinstance(mreg, list):
-                        print('[*] plugin {0} registered to receive messages with {1}'.format(mname, mreg))
-                        pluginList.append((mclass, mreg, mpriority))
-    return pluginList
-
-
-def checkPlugins(pluginList, lastPluginCheck):
-    if abs(datetime.now() - lastPluginCheck).seconds > options.plugincheckfrequency:
-        # print('[*] checking plugins')
-        lastPluginCheck = datetime.now()
-        pluginList = registerPlugins()
-        return pluginList, lastPluginCheck
-    else:
-        return pluginList, lastPluginCheck
-
-
-def flattenDict(inDict, pre=None, values=True):
-    '''given a dictionary, potentially with multiple sub dictionaries
-       return a period delimited version of the dict with or without values
-       i.e. {'something':'value'} becomes something=value
-            {'something':{'else':'value'}} becomes something.else=value
-    '''
-    pre = pre[:] if pre else []
-    if isinstance(inDict, dict):
-        for key, value in inDict.iteritems():
-            if isinstance(value, dict):
-                for d in flattenDict(value, pre + [key], values):
-                    yield d
-            else:
-                if pre:
-                    if values:
-                        if isinstance(value, str):
-                            yield '.'.join(pre) + '.' + key + '=' + str(value)
-                        elif isinstance(value, unicode):
-                            yield '.'.join(pre) + '.' + key + '=' + value.encode('ascii', 'ignore')
-                        elif value is None:
-                            yield '.'.join(pre) + '.' + key + '=None'
-                    else:
-                        yield '.'.join(pre) + '.' + key
-                else:
-                    if values:
-                        if isinstance(value, str):
-                            yield key + '=' + str(value)
-                        elif isinstance(value, unicode):
-                            yield key + '=' + value.encode('ascii', 'ignore')
-                        elif value is None:
-                            yield key + '=None'
-                    else:
-                        yield key
-    else:
-        yield '-'.join(pre) + '.' + inDict
-
-
-def dict2List(inObj):
-    '''given a dictionary, potentially with multiple sub dictionaries
-       return a list of the dict keys and values
-    '''
-    if isinstance(inObj, dict):
-        for key, value in inObj.iteritems():
-            if isinstance(value, dict):
-                for d in dict2List(value):
-                    yield d
-            elif isinstance(value, list):
-                yield key.encode('ascii', 'ignore').lower()
-                for l in dict2List(value):
-                    yield l
-            else:
-                yield key.encode('ascii', 'ignore').lower()
-                if isinstance(value, str):
-                    yield value.lower()
-                elif isinstance(value, unicode):
-                    yield value.encode('ascii', 'ignore').lower()
-                else:
-                    yield value
-    elif isinstance(inObj, list):
-        for v in inObj:
-            if isinstance(v, str):
-                yield v.lower()
-            elif isinstance(v, unicode):
-                yield v.encode('ascii', 'ignore').lower()
-            elif isinstance(v, list):
-                for l in dict2List(v):
-                    yield l
-            elif isinstance(v,dict):
-                for d in dict2List(v):
-                    yield d
-            else:
-                yield v
-    else:
-        yield ''
-
-
-def sendEventToPlugins(anevent, metadata, pluginList):
-    '''compare the event to the plugin registrations.
-       plugins register with a list of keys or values
-       or values they want to match on
-       this function compares that registration list
-       to the current event and sends the event to plugins
-       in order
-    '''
-    if not isinstance(anevent, dict):
-        raise TypeError('event is type {0}, should be a dict'.format(type(anevent)))
-
-    # expecting tuple of module,criteria,priority in pluginList
-    # sort the plugin list by priority
-    for plugin in sorted(pluginList, key=itemgetter(2), reverse=False):
-        # assume we don't run this event through the plugin
-        send = False
-        if isinstance(plugin[1], list):
-            try:
-                if (set(plugin[1]).intersection([e for e in dict2List(anevent)])):
-                    send = True
-            except TypeError:
-                sys.stderr.write('TypeError on set intersection for dict {0}'.format(anevent))
-                return (anevent, metadata)
-        if send:
-            (anevent, metadata) = plugin[0].onMessage(anevent, metadata)
-            if anevent is None:
-                # plug-in is signalling to drop this message
-                # early exit
-                return (anevent, metadata)
-
-    return (anevent, metadata)
-
-
 def main():
     # connect and declare the message queue/kombu objects.
     # only py-amqp supports ssl and doesn't recognize amqps
@@ -537,9 +362,6 @@ if __name__ == '__main__':
     # open ES connection globally so we don't waste time opening it per message
     es = esConnect()
 
-    # force a check for plugins and establish the plugin list
-    pluginList = list()
-    lastPluginCheck = datetime.now()-timedelta(minutes=60)
-    pluginList, lastPluginCheck = checkPlugins(pluginList, lastPluginCheck)
+    pluginList = registerPlugins()
 
     main()

--- a/mq/esworker_papertrail.py
+++ b/mq/esworker_papertrail.py
@@ -80,7 +80,7 @@ class PTRequestor(object):
             if maxid is None:
                 break
             if len(self._events.keys()) > self._evmax:
-                logger.warning('papertrail esworker hitting event request limit\n')
+                logger.warning('papertrail esworker hitting event request limit')
                 break
         # cache event ids we return to allow for some duplicate filtering checks
         # during next run
@@ -354,9 +354,9 @@ class taskConsumer(object):
 
 def main():
     if hasUWSGI:
-        logger.info("started as uwsgi mule {0}\n".format(uwsgi.mule_id()))
+        logger.info("started as uwsgi mule {0}".format(uwsgi.mule_id()))
     else:
-        logger.info('started without uwsgi\n')
+        logger.info('started without uwsgi')
 
     # establish api interface with papertrail
     ptRequestor = PTRequestor(options.ptapikey, evmax=options.ptquerymax)

--- a/mq/esworker_sns_sqs.py
+++ b/mq/esworker_sns_sqs.py
@@ -179,12 +179,12 @@ class taskConsumer(object):
 
 def main():
     if hasUWSGI:
-        logger.info("started as uwsgi mule {0}\n".format(uwsgi.mule_id()))
+        logger.info("started as uwsgi mule {0}".format(uwsgi.mule_id()))
     else:
-        logger.info('started without uwsgi\n')
+        logger.info('started without uwsgi')
 
     if options.mqprotocol not in ('sqs'):
-        logger.error('Can only process SQS queues, terminating\n')
+        logger.error('Can only process SQS queues, terminating')
         sys.exit(1)
 
     mqConn = boto.sqs.connect_to_region(options.region, aws_access_key_id=options.accesskey, aws_secret_access_key=options.secretkey)

--- a/mq/esworker_sns_sqs.py
+++ b/mq/esworker_sns_sqs.py
@@ -133,6 +133,9 @@ class taskConsumer(object):
                     except ValueError:
                         event['summary'] = message_value
             (event, metadata) = sendEventToPlugins(event, metadata, self.pluginList)
+            # Drop message if plugins set to None
+            if event is None:
+                return
             self.save_event(event, metadata)
         except Exception as e:
             logger.exception(e)

--- a/mq/esworker_sns_sqs.py
+++ b/mq/esworker_sns_sqs.py
@@ -20,8 +20,6 @@ import boto.sqs
 from boto.sqs.message import RawMessage
 import kombu
 
-import sys
-import os
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../lib'))
 from utilities.toUTC import toUTC
 from elasticsearch_client import ElasticsearchClient, ElasticsearchBadServer, ElasticsearchInvalidIndex, ElasticsearchException

--- a/mq/esworker_sqs.py
+++ b/mq/esworker_sqs.py
@@ -12,25 +12,26 @@
 
 
 import json
-import math
 import os
-import pynsive
 import sys
 import socket
 import time
 from configlib import getConfig, OptionParser
-from datetime import datetime, timedelta
-from operator import itemgetter
+from datetime import datetime
 import boto.sqs
 from boto.sqs.message import RawMessage
 import base64
 import kombu
 
-import sys
-import os
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../lib'))
 from utilities.toUTC import toUTC
+from utilities.to_unicode import toUnicode
+from utilities.remove_at import removeAt
+from utilities.is_cef import isCEF
 from elasticsearch_client import ElasticsearchClient, ElasticsearchBadServer, ElasticsearchInvalidIndex, ElasticsearchException
+
+from lib.plugins import sendEventToPlugins, registerPlugins
+
 
 # running under uwsgi?
 try:
@@ -38,39 +39,6 @@ try:
     hasUWSGI = True
 except ImportError as e:
     hasUWSGI = False
-
-
-def removeAt(astring):
-    '''remove the leading @ from a string'''
-    return astring.replace('@', '')
-
-
-def isCEF(aDict):
-    # determine if this is a CEF event
-    # could be an event posted to the /cef http endpoint
-    if 'endpoint' in aDict.keys() and aDict['endpoint'] == 'cef':
-        return True
-    # maybe it snuck in some other way
-    # check some key CEF indicators (the header fields)
-    if 'fields' in aDict.keys() and isinstance(aDict['fields'], dict):
-        lowerKeys = [s.lower() for s in aDict['fields'].keys()]
-        if 'devicevendor' in lowerKeys and 'deviceproduct' in lowerKeys and 'deviceversion' in lowerKeys:
-            return True
-    if 'details' in aDict.keys() and isinstance(aDict['details'], dict):
-        lowerKeys = [s.lower() for s in aDict['details'].keys()]
-        if 'devicevendor' in lowerKeys and 'deviceproduct' in lowerKeys and 'deviceversion' in lowerKeys:
-            return True
-    return False
-
-
-def toUnicode(obj, encoding='utf-8'):
-    if type(obj) in [int, long, float, complex]:
-        # likely a number, convert it to string to get to unicode
-        obj = str(obj)
-    if isinstance(obj, basestring):
-        if not isinstance(obj, unicode):
-            obj = unicode(obj, encoding)
-    return obj
 
 
 def keyMapping(aDict):
@@ -357,112 +325,6 @@ class taskConsumer(object):
                 "esworker.sqs exception in events queue %r\n" % e)
 
 
-def registerPlugins():
-    pluginList = list()   # tuple of module,registration dict,priority
-    plugin_manager = pynsive.PluginManager()
-    if os.path.exists('plugins'):
-        modules = pynsive.list_modules('plugins')
-        for mname in modules:
-            module = pynsive.import_module(mname)
-            reload(module)
-            if not module:
-                raise ImportError('Unable to load module {}'.format(mname))
-            else:
-                if 'message' in dir(module):
-                    mclass = module.message()
-                    mreg = mclass.registration
-                    if 'priority' in dir(mclass):
-                        mpriority = mclass.priority
-                    else:
-                        mpriority = 100
-                    if isinstance(mreg, list):
-                        print('[*] plugin {0} registered to receive messages with {1}'.format(mname, mreg))
-                        pluginList.append((mclass, mreg, mpriority))
-    return pluginList
-
-
-def checkPlugins(pluginList, lastPluginCheck):
-    if abs(datetime.now() - lastPluginCheck).seconds > options.plugincheckfrequency:
-        # print('[*] checking plugins')
-        lastPluginCheck = datetime.now()
-        pluginList = registerPlugins()
-        return pluginList, lastPluginCheck
-    else:
-        return pluginList, lastPluginCheck
-
-
-def dict2List(inObj):
-    '''given a dictionary, potentially with multiple sub dictionaries
-       return a list of the dict keys and values
-    '''
-    if isinstance(inObj, dict):
-        for key, value in inObj.iteritems():
-            if isinstance(value, dict):
-                for d in dict2List(value):
-                    yield d
-            elif isinstance(value, list):
-                yield key.encode('ascii', 'ignore').lower()
-                for l in dict2List(value):
-                    yield l
-            else:
-                yield key.encode('ascii', 'ignore').lower()
-                if isinstance(value, str):
-                    yield value.lower()
-                elif isinstance(value, unicode):
-                    yield value.encode('ascii', 'ignore').lower()
-                else:
-                    yield value
-    elif isinstance(inObj, list):
-        for v in inObj:
-            if isinstance(v, str):
-                yield v.lower()
-            elif isinstance(v, unicode):
-                yield v.encode('ascii', 'ignore').lower()
-            elif isinstance(v, list):
-                for l in dict2List(v):
-                    yield l
-            elif isinstance(v,dict):
-                for d in dict2List(v):
-                    yield d
-            else:
-                yield v
-    else:
-        yield ''
-
-
-def sendEventToPlugins(anevent, metadata, pluginList):
-    '''compare the event to the plugin registrations.
-       plugins register with a list of keys or values
-       or values they want to match on
-       this function compares that registration list
-       to the current event and sends the event to plugins
-       in order
-    '''
-    if not isinstance(anevent, dict):
-        raise TypeError('event is type {0}, should be a dict'.format(type(anevent)))
-
-    # expecting tuple of module,criteria,priority in pluginList
-    # sort the plugin list by priority
-    for plugin in sorted(pluginList, key=itemgetter(2), reverse=False):
-        # assume we don't run this event through the plugin
-        send = False
-        if isinstance(plugin[1], list):
-            try:
-                if (set(plugin[1]).intersection([e for e in dict2List(anevent)])):
-                    send = True
-            except TypeError:
-                sys.stderr.write('TypeError on set intersection for dict {0}'.format(anevent))
-                return (anevent, metadata)
-        if send:
-            (anevent, metadata) = plugin[0].onMessage(anevent, metadata)
-            if anevent is None:
-                # plug-in is signalling to drop this message
-                # early exit
-                return (anevent, metadata)
-
-    return (anevent, metadata)
-
-
 def main():
     # meant only to talk to SQS using boto
     # and process events as json.
@@ -539,9 +401,6 @@ if __name__ == '__main__':
     # open ES connection globally so we don't waste time opening it per message
     es = esConnect()
 
-    # force a check for plugins and establish the plugin list
-    pluginList = list()
-    lastPluginCheck = datetime.now()-timedelta(minutes=60)
-    pluginList, lastPluginCheck = checkPlugins(pluginList, lastPluginCheck)
+    pluginList = registerPlugins()
 
     main()

--- a/mq/lib/plugins.py
+++ b/mq/lib/plugins.py
@@ -14,6 +14,7 @@ import pynsive
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../lib'))
 from utilities.dict2List import dict2List
+from utilities.logger import logger
 
 
 def sendEventToPlugins(anevent, metadata, pluginList):
@@ -37,7 +38,7 @@ def sendEventToPlugins(anevent, metadata, pluginList):
                 if (set(plugin[1]).intersection([e for e in dict2List(anevent)])):
                     send = True
             except TypeError:
-                sys.stderr.write('TypeError on set intersection for dict {0}'.format(anevent))
+                logger.error('TypeError on set intersection for dict {0}'.format(anevent))
                 return (anevent, metadata)
         if send:
             (anevent, metadata) = plugin[0].onMessage(anevent, metadata)
@@ -67,7 +68,7 @@ def registerPlugins():
                     else:
                         mpriority = 100
                     if isinstance(mreg, list):
-                        print('[*] plugin {0} registered to receive messages with {1}'.format(mname, mreg))
+                        logger.info('[*] plugin {0} registered to receive messages with {1}'.format(mname, mreg))
                         pluginList.append((mclass, mreg, mpriority))
     return pluginList
 

--- a/mq/plugins/complianceitems.py
+++ b/mq/plugins/complianceitems.py
@@ -5,6 +5,9 @@
 
 import hashlib
 import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../lib'))
+from utilities.logger import logger
 
 
 class message(object):
@@ -12,7 +15,7 @@ class message(object):
         self.registration = ['complianceitems']
         self.priority = 20
 
-    def validate(self,item):
+    def validate(self, item):
         """
             Validate that a compliance item has all the necessary keys
         """
@@ -31,7 +34,7 @@ class message(object):
                 return False
         return True
 
-    def cleanup_item(self,item):
+    def cleanup_item(self, item):
         ci = {}
         ci['target'] = item['target']
         ci['policy'] = {}
@@ -61,7 +64,7 @@ class message(object):
             index, with doctype last_known_state
         """
         if not self.validate(message['details']):
-            sys.stderr.write('error: invalid format for complianceitem {0}'.format(message))
+            logger.error('Invalid format for complianceitem {0}'.format(message))
             return (None, None)
         item = self.cleanup_item(message['details'])
         docidstr = 'complianceitems'

--- a/mq/plugins/vulnerability.py
+++ b/mq/plugins/vulnerability.py
@@ -5,6 +5,9 @@
 
 import hashlib
 import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../lib'))
+from utilities.logger import logger
 
 
 class message(object):
@@ -20,10 +23,14 @@ class message(object):
     def __init__(self):
         self.registration = ['vulnerability']
         self.priority = 20
-        self.handler_v1 = self.version_handler(self.MSG_VERSION_1, self.validate_v1,
-                self.calculate_id_v1)
-        self.handler_v2 = self.version_handler(self.MSG_VERSION_2, self.validate_v2,
-                self.calculate_id_v2)
+        self.handler_v1 = self.version_handler(
+            self.MSG_VERSION_1,
+            self.validate_v1,
+            self.calculate_id_v1)
+        self.handler_v2 = self.version_handler(
+            self.MSG_VERSION_2,
+            self.validate_v2,
+            self.calculate_id_v2)
 
     def get_handler(self, message):
         if 'version' not in message:
@@ -59,24 +66,26 @@ class message(object):
         return True
 
     def calculate_id_v1(self, message):
-        s = '{0}|{1}|{2}'.format(message['asset']['assetid'],
+        s = '{0}|{1}|{2}'.format(
+            message['asset']['assetid'],
             message['vuln']['vulnid'], message['sourcename'])
         return hashlib.md5(s).hexdigest()
 
     def calculate_id_v2(self, message):
-        s = '{0}|{1}|{2}|{3}'.format(message['zone'],
-                message['sourcename'], message['asset']['hostname'],
-                message['asset']['ipaddress'])
+        s = '{0}|{1}|{2}|{3}'.format(
+            message['zone'],
+            message['sourcename'], message['asset']['hostname'],
+            message['asset']['ipaddress'])
         return hashlib.md5(s).hexdigest()
 
     def onMessage(self, message, metadata):
         if metadata['doc_type'] != 'vulnerability':
             return (message, metadata)
         handler = self.get_handler(message)
-        if handler == None:
+        if handler is None:
             return (None, None)
         if not handler.validate(message):
-            sys.stderr.write('error: invalid format for vulnerability {0}'.format(message))
+            logger.error('Invalid format for vulnerability {0}'.format(message))
             return (None, None)
         metadata['id'] = handler.calculate_id(message)
         metadata['doc_type'] = 'vulnerability_state'


### PR DESCRIPTION
In addition, we remove some unused code/refactor some common functions into lib.
We also print the malformed event to the log for each worker, so that troubleshooting issues will be easier.