### PR TITLE
Changed python virtualenv locations in cron/*.sh

### DIFF
--- a/cron/auth02mozdef.sh
+++ b/cron/auth02mozdef.sh
@@ -6,5 +6,5 @@
 # Author: gdestuynder@mozilla.com
 
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/auth02mozdef.py

--- a/cron/backupSnapshot.sh
+++ b/cron/backupSnapshot.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/backupSnapshot.py -c /opt/mozdef/envs/mozdef/cron/backup.conf

--- a/cron/collectAttackers.sh
+++ b/cron/collectAttackers.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/collectAttackers.py -c /opt/mozdef/envs/mozdef/cron/collectAttackers.conf

--- a/cron/collectSSHFingerprints.sh
+++ b/cron/collectSSHFingerprints.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/collectSSHFingerprints.py -c /opt/mozdef/envs/mozdef/cron/collectSSHFingerprints.conf
 

--- a/cron/correlateUserMacAddress.sh
+++ b/cron/correlateUserMacAddress.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/correlateUserMacAddress.py -c /opt/mozdef/envs/mozdef/cron/correlateUserMacAddress.conf
 

--- a/cron/createIPBlockList.sh
+++ b/cron/createIPBlockList.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/createIPBlockList.py -c /opt/mozdef/envs/mozdef/cron/createIPBlockList.conf
 

--- a/cron/duo_logpull.sh
+++ b/cron/duo_logpull.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/duo_logpull.py -c /opt/mozdef/envs/mozdef/cron/duo_logpull.conf

--- a/cron/duo_logpull_releng.sh
+++ b/cron/duo_logpull_releng.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source /opt/mozdef/envs/mozdef/bin/activate
+source /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/duo_logpull.py -c /opt/mozdef/envs/mozdef/cron/duo_logpull_releng.conf
 

--- a/cron/esMaint.sh
+++ b/cron/esMaint.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/rotateIndexes.py -c /opt/mozdef/envs/mozdef/cron/backup.conf
 

--- a/cron/eventStats.sh
+++ b/cron/eventStats.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/eventStats.py -c /opt/mozdef/envs/mozdef/cron/eventStats.conf

--- a/cron/google2mozdef.sh
+++ b/cron/google2mozdef.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/google2mozdef.py -c /opt/mozdef/envs/mozdef/cron/google2mozdef.conf
 

--- a/cron/healthAndStatus-fxa.sh
+++ b/cron/healthAndStatus-fxa.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/healthAndStatus.py -c /opt/mozdef/envs/mozdef/cron/healthAndStatus.fxa.conf

--- a/cron/healthAndStatus-mdc1.sh
+++ b/cron/healthAndStatus-mdc1.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/healthAndStatus.py -c /opt/mozdef/envs/mozdef/cron/healthAndStatus.mdc1.conf

--- a/cron/healthAndStatus.sh
+++ b/cron/healthAndStatus.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/healthAndStatus.py -c /opt/mozdef/envs/mozdef/cron/healthAndStatus.conf

--- a/cron/healthToMongo.sh
+++ b/cron/healthToMongo.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/healthToMongo.py -c /opt/mozdef/envs/mozdef/cron/healthToMongo.conf

--- a/cron/import_threat_exchange.sh
+++ b/cron/import_threat_exchange.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/import_threat_exchange.py -c /opt/mozdef/envs/mozdef/cron/import_threat_exchange.conf

--- a/cron/okta2mozdef.sh
+++ b/cron/okta2mozdef.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/okta2mozdef.py -c /opt/mozdef/envs/mozdef/cron/okta2mozdef.conf
 

--- a/cron/pruneES.sh
+++ b/cron/pruneES.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/pruneIndexes.py -c /opt/mozdef/envs/mozdef/cron/backup.conf
 

--- a/cron/syncAlertsToMongo.sh
+++ b/cron/syncAlertsToMongo.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.py -c /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.conf

--- a/cron/update_generic_alerts.sh
+++ b/cron/update_generic_alerts.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/update_generic_alerts.py -c /opt/mozdef/envs/mozdef/cron/update_generic_alerts.conf

--- a/cron/update_geolite_db.sh
+++ b/cron/update_geolite_db.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/update_geolite_db.py -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.conf

--- a/cron/update_ip_list.sh
+++ b/cron/update_ip_list.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/update_ip_list.py -c /opt/mozdef/envs/mozdef/cron/update_ip_list.conf

--- a/cron/verify_event_fields.sh
+++ b/cron/verify_event_fields.sh
@@ -5,5 +5,5 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/verify_event_fields.py -c /opt/mozdef/envs/mozdef/cron/verify_event_fields.conf

--- a/cron/vidyo2MozDef.sh
+++ b/cron/vidyo2MozDef.sh
@@ -5,6 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-source  /opt/mozdef/envs/mozdef/bin/activate
+source  /opt/mozdef/envs/python/bin/activate
 /opt/mozdef/envs/mozdef/cron/vidyo2MozDef.py -c /opt/mozdef/envs/mozdef/cron/vidyo2MozDef.conf
 


### PR DESCRIPTION
Changed python virtualenv to /opt/mozdef/envs/python in `cron/*.sh` files
FIxes #421 