### PR TITLE
Add publickey to TermsMatch 

### DIFF
--- a/alerts/bruteforce_ssh.py
+++ b/alerts/bruteforce_ssh.py
@@ -18,7 +18,7 @@ class AlertBruteforceSsh(AlertTask):
         search_query.add_must([
             PhraseMatch('summary', 'failed'),
             TermMatch('details.program', 'sshd'),
-            TermsMatch('summary', ['login', 'invalid', 'ldap_count_entries'])
+            TermsMatch('summary', ['login', 'invalid', 'ldap_count_entries', 'publickey'])
         ])
 
         for ip_address in self.config.skiphosts.split():


### PR DESCRIPTION
Currently we do not see any failed logins that use publickeys, we should be seeing these.
I expect the rate of fire for this alert to increase significantly as we are about to find out where possible script issues are in addition to users attempting to log into hosts where their key is not present.