### PR TITLE
Fix XHR 302s with an access proxy. This fixes the page "hanging" after the access proxy tries to silently authenticate.

### DIFF
--- a/meteor/app/client/mozdef.js
+++ b/meteor/app/client/mozdef.js
@@ -393,4 +393,37 @@ if (Meteor.isClient) {
     Meteor.logoutViaAccounts = function(callback) {
         return Accounts.logout(callback);
     };
+    // Intercepts all XHRs and reload the main browser window on redirect or request error (such as CORS denying access)
+    // This is because, if you run MozDef behind an access-proxy, the requests maybe 302'd to an authentication
+    // provider, but Meteor does not know or handle this. Reloading the main browser window will send the user to the
+    // authentication provider correctly and follow the 302.
+    // Note that since they're 302's they will ALWAYS cause a CORS error, which we keep as this is the SAFE way to
+    // handle this situation.
+    (function(xhr) {
+        var authenticationType = mozdef.authenticationType.toLowerCase();
+        function intercept_xhr(xhrInstance) {
+            // Verify a user is actually logged in and Meteor is running
+            if ((Meteor.user() !== null) && (Meteor.status().connected)) {
+                // Status 0 means the request failed (CORS denies access)
+                if (xhrInstance.readyState == 4 && (xhrInstance.status == 302 || xhrInstance.status == 0)) {
+                        location.reload();
+                }
+            }
+        }
+        var send = xhr.send;
+        xhr.send = function(data) {
+            var origFunc = this.onreadystatechange;
+            if (origFunc) {
+                this.onreadystatechange = function() {
+                    // We only start hooking for oidc authentication, as this is the only method that is currently
+                    // REQUIRING an access proxy and thus likely to run into 302s
+                    if (authenticationType == 'oidc'){
+                        intercept_xhr(this);
+                    }
+                    return origFunc.apply(this, arguments);
+                };
+            }
+            return send.apply(this, arguments);
+        };
+    })(XMLHttpRequest.prototype);
 };


### PR DESCRIPTION
What would happen:

- XHR triggers while page is open
- User session has to be verified with an authentication provider by an
access proxy (Meteor is unaware of this)
- XHR gets a 302 reply to the authentication provider, but doesn't know
what to do with it.
- Additionally, CORS headers deny the 302 (rightfully so)
- All XHRs fail from now on, Mozdef webui stops working until you
manually refresh the page.

What happens with this patch:

- XHR triggers while page is open
- User session has to be verified with an authentication provider by an
access proxy (Meteor is unaware of this)
+ XHR reply is intercepted and checks if it's a 302 or 0 (CORS denial)
status
++ if so, the page is automatically refreshed and the user gets silently
reauthenticated as needed