### PR TITLE
Add a "copy to clipboard" option for ip addresses

### DIFF
--- a/meteor/app/client/alertdetails.html
+++ b/meteor/app/client/alertdetails.html
@@ -47,12 +47,6 @@ Copyright (c) 2014 Mozilla Corporation
             {{/each}}
         </tbody>
     </table>
-    {{>whoismodal}}
-    {{>dshieldmodal}}
-    {{>cifmodal}}
-    {{>blockIPModal}}
-    {{>intelmodal}}
-
 </div>
 
 </template>

--- a/meteor/app/client/alertdetails.js
+++ b/meteor/app/client/alertdetails.js
@@ -59,26 +59,6 @@ if (Meteor.isClient) {
             //debugLog(template.firstNode.baseURI);
             //reroute to full blown edit form after this minimal input is complete
             Router.go('/incident/' + newid + '/edit');
-        },
-        "click .ipmenu-whois": function(e,t){
-            Session.set('ipwhoisipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalwhoiswindow').modal()
-        },
-        "click .ipmenu-dshield": function(e,t){
-            Session.set('ipdshieldipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modaldshieldwindow').modal()
-        },
-        "click .ipmenu-blockip": function(e,t){
-            Session.set('blockIPipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalBlockIPWindow').modal()
-        },
-        "click .ipmenu-cif": function(e,t){
-            Session.set('ipcifipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalcifwindow').modal()
-        },
-        "click .ipmenu-intel": function(e,t){
-            Session.set('ipintelipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalintelwindow').modal()
         }
     });
 }

--- a/meteor/app/client/alertssummary.html
+++ b/meteor/app/client/alertssummary.html
@@ -88,10 +88,6 @@ Copyright (c) 2014 Mozilla Corporation
             </table>
         </div>
     </div>
-    {{>whoismodal}}
-    {{>dshieldmodal}}
-    {{>blockIPModal}}
-    {{>intelmodal}}
 </div>
 </template>
 

--- a/meteor/app/client/alertsummary.js
+++ b/meteor/app/client/alertsummary.js
@@ -48,26 +48,7 @@ if (Meteor.isClient) {
             refreshAlertsData();
             dc.renderAll("alertssummary");
             },
-        "click .ipmenu-whois": function(e,t){
-            Session.set('ipwhoisipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalwhoiswindow').modal()
-        },
-        "click .ipmenu-dshield": function(e,t){
-            Session.set('ipdshieldipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modaldshieldwindow').modal()
-        },
-        "click .ipmenu-blockip": function(e,t){
-            Session.set('blockIPipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalBlockIPWindow').modal()
-        },
-        "click .ipmenu-intel": function(e,t){
-            Session.set('ipintelipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalintelwindow').modal()
-        },
-        "click .dropdown": function(e,t){
-            $(e.target).addClass("hover");
-            $('ul:first',$(e.target)).css('visibility', 'visible');
-        },
+
         "click .btnAlertAck": function(e,t){
             id = $(e.target).attr('data-target');
             //acknowledge the alert

--- a/meteor/app/client/attackerdetails.html
+++ b/meteor/app/client/attackerdetails.html
@@ -54,11 +54,6 @@ Copyright (c) 2014 Mozilla Corporation
             </tbody>
         </table>
     </div>
-    {{>whoismodal}}
-    {{>dshieldmodal}}
-    {{>cifmodal}}
-    {{>blockIPModal}}
-    {{>intelmodal}}
 </div>
 
 </template>

--- a/meteor/app/client/attackerdetails.js
+++ b/meteor/app/client/attackerdetails.js
@@ -10,26 +10,6 @@ if (Meteor.isClient) {
     Template.attackerdetails.events({
         "change #attackerCategory": function(e,t){
             attackers.update(Session.get('attackerID'), {$set: {'category':$('#attackerCategory').val()}});
-        },
-        "click .ipmenu-whois": function(e,t){
-            Session.set('ipwhoisipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalwhoiswindow').modal()
-        },
-        "click .ipmenu-dshield": function(e,t){
-            Session.set('ipdshieldipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modaldshieldwindow').modal()
-        },
-        "click .ipmenu-blockip": function(e,t){
-            Session.set('blockIPipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalBlockIPWindow').modal()
-        },
-        "click .ipmenu-cif": function(e,t){
-            Session.set('ipcifipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalcifwindow').modal()
-        },
-        "click .ipmenu-intel": function(e,t){
-            Session.set('ipintelipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalintelwindow').modal()
         }
     });
 

--- a/meteor/app/client/ipBlocklistTable.html
+++ b/meteor/app/client/ipBlocklistTable.html
@@ -29,11 +29,6 @@ Copyright (c) 2014 Mozilla Corporation
                 </tbody>
             </table>
         </div>
-        {{>whoismodal}}
-        {{>dshieldmodal}}
-        {{>cifmodal}}
-        {{>blockIPModal}}
-        {{>intelmodal}}
     </div>
 </template>
 

--- a/meteor/app/client/ipBlocklistTable.js
+++ b/meteor/app/client/ipBlocklistTable.js
@@ -27,26 +27,6 @@ if (Meteor.isClient) {
         "click .ipblockdelete": function(e,t){
             ipblocklist.remove(this._id);
             Session.set('displayMessage','Deleted ipblock for & ' + this.address);
-        },
-        "click .ipmenu-whois": function(e,t){
-            Session.set('ipwhoisipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalwhoiswindow').modal()
-        },
-        "click .ipmenu-dshield": function(e,t){
-            Session.set('ipdshieldipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modaldshieldwindow').modal()
-        },
-        "click .ipmenu-blockip": function(e,t){
-            Session.set('blockIPipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalBlockIPWindow').modal()
-        },
-        "click .ipmenu-cif": function(e,t){
-            Session.set('ipcifipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalcifwindow').modal()
-        },
-        "click .ipmenu-intel": function(e,t){
-            Session.set('ipintelipaddress',($(e.target).attr('data-ipaddress')));
-            $('#modalintelwindow').modal()
         }
     });
 

--- a/meteor/app/client/layout.js
+++ b/meteor/app/client/layout.js
@@ -7,7 +7,7 @@ Copyright (c) 2014 Mozilla Corporation
 
 if (Meteor.isClient) {
     //events that could fire in any sub template
-    Template.menu.events({
+    Template.layout.events({
         "click .ipmenu-copy": function(e,t){
             var ipText=$(e.target).attr('data-ipaddress')
             var ipTextArea = document.createElement("textarea");

--- a/meteor/app/client/menu.js
+++ b/meteor/app/client/menu.js
@@ -23,6 +23,26 @@ if (Meteor.isClient) {
                 Session.set('errorMessage','copy failed & ' + JSON.stringify(err));
             }
             document.body.removeChild(ipTextArea);
+        },
+        "click .ipmenu-whois": function(e,t){
+            Session.set('ipwhoisipaddress',($(e.target).attr('data-ipaddress')));
+            $('#modalwhoiswindow').modal()
+        },
+        "click .ipmenu-dshield": function(e,t){
+            Session.set('ipdshieldipaddress',($(e.target).attr('data-ipaddress')));
+            $('#modaldshieldwindow').modal()
+        },
+        "click .ipmenu-blockip": function(e,t){
+            Session.set('blockIPipaddress',($(e.target).attr('data-ipaddress')));
+            $('#modalBlockIPWindow').modal()
+        },
+        "click .ipmenu-intel": function(e,t){
+            Session.set('ipintelipaddress',($(e.target).attr('data-ipaddress')));
+            $('#modalintelwindow').modal()
+        },
+        "click .dropdown": function(e,t){
+            $(e.target).addClass("hover");
+            $('ul:first',$(e.target)).css('visibility', 'visible');
         }
     });
 }

--- a/meteor/app/client/menu.js
+++ b/meteor/app/client/menu.js
@@ -1,0 +1,28 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+Copyright (c) 2014 Mozilla Corporation
+*/
+
+if (Meteor.isClient) {
+    //events that could fire in any sub template
+    Template.menu.events({
+        "click .ipmenu-copy": function(e,t){
+            var ipText=$(e.target).attr('data-ipaddress')
+            var ipTextArea = document.createElement("textarea");
+            ipTextArea.value = ipText;
+            document.body.appendChild(ipTextArea);
+            ipTextArea.focus();
+            ipTextArea.select();
+            try {
+              var successful = document.execCommand('copy');
+              var msg = successful ? 'successful' : 'unsuccessful';
+              Session.set('displayMessage','copy & '+ msg);
+            } catch (err) {
+                Session.set('errorMessage','copy failed & ' + JSON.stringify(err));
+            }
+            document.body.removeChild(ipTextArea);
+        }
+    });
+}

--- a/meteor/app/client/mozdef.js
+++ b/meteor/app/client/mozdef.js
@@ -292,16 +292,17 @@ if (Meteor.isClient) {
 
             //add the drop down menu
             ipmenu=$("<ul class='sub_menu' />");
+            copyitem=$("<li><a class='ipmenu-copy' data-ipaddress='" + iptext + "'href='#'>copy</a></li>");
             whoisitem=$("<li><a class='ipmenu-whois' data-ipaddress='" + iptext + "'href='#'>whois</a></li>");
             dshielditem=$("<li><a class='ipmenu-dshield' data-ipaddress='" + iptext + "'href='#'>dshield</a></li>");
             intelitem=$("<li><a class='ipmenu-intel' data-ipaddress='" + iptext + "'href='#'>ip intel</a></li>");
             blockIPitem=$("<li><a class='ipmenu-blockip' data-ipaddress='" + iptext + "'href='#'>block</a></li>");
 
-            ipmenu.append(whoisitem,dshielditem,intelitem,blockIPitem);
+            ipmenu.append(copyitem,whoisitem,dshielditem,intelitem,blockIPitem);
 
             $(this).parent().parent().append(ipmenu);
         });
-        //return raw html, consume as {{{ ipDecorate fieldname }} in a meteor template
+        //return raw html, consume as {{{ ipDecorate fieldname }}} in a meteor template
         return anelement.prop('outerHTML');
     });
 

--- a/meteor/mozdef.html
+++ b/meteor/mozdef.html
@@ -41,7 +41,10 @@ Copyright (c) 2014 Mozilla Corporation
             {{/if}}
         {{/if}}
 
-
+{{>whoismodal}}
+{{>dshieldmodal}}
+{{>blockIPModal}}
+{{>intelmodal}}
 
 </template>
 


### PR DESCRIPTION
This adds a 'copy to clipboard' option for the ip address drop down menu and cleans up the ip drop down modal html/js to be centralized in the layout template rather than duplicated in all the screens that may need it. 