### PR TITLE
Add FQDN/DNS block page

### DIFF
--- a/cron/createFDQNBlockList.py
+++ b/cron/createFDQNBlockList.py
@@ -104,12 +104,12 @@ def main():
                     ]},
                 },
                 {"$project":{"address":1}},
-                {"$limit": options.iplimit}
+                {"$limit": options.fqdnlimit}
             ])
         FQDNList=[]
         for fqdn in fqdnCursor:
             # TODO: figure out what to do here
-            FQDNList.append(ip['address'])
+            FQDNList.append(fqdn['address'])
         # to text
         with open(options.outputfile, 'w') as outputfile:
             for fqdn in FQDNList:
@@ -121,7 +121,7 @@ def main():
 
 
     except ValueError as e:
-        logger.error("Exception %r generating IP block list" % e)
+        logger.error("Exception %r generating FQDN block list" % e)
 
 
 def initConfig():
@@ -152,7 +152,7 @@ def initConfig():
     options.expireage = getConfig('expireage',1,options.configfile)
 
     # Max FQDNs to emit
-    options.iplimit = getConfig('fqdnlimit', 1000, options.configfile)
+    options.fqdnlimit = getConfig('fqdnlimit', 1000, options.configfile)
 
     # AWS creds
     options.aws_access_key_id=getConfig('aws_access_key_id','',options.configfile)          #aws credentials to use to connect to mozilla_infosec_blocklist

--- a/cron/createFDQNBlockList.py
+++ b/cron/createFDQNBlockList.py
@@ -124,7 +124,7 @@ def initConfig():
     options.mongoport = getConfig('mongoport', 3001, options.configfile)
 
     # FQDN whitelist as a \n separted file of example.com or foo.bar.com style names
-    self.options.fqdn_whitelist_file = getConfig('fqdn_whitelist_file', '/dev/null', self.configfile)
+    options.fqdn_whitelist_file = getConfig('fqdn_whitelist_file', '/dev/null', options.configfile)
     options.fqdnwhitelist = parse_fqdn_whitelist(options.fqdn_whitelist_file)
 
     # Output File Name

--- a/cron/createFDQNBlockList.py
+++ b/cron/createFDQNBlockList.py
@@ -78,7 +78,6 @@ def main():
         client = MongoClient(options.mongohost, options.mongoport)
         mozdefdb = client.meteor
         fqdnblocklist = mozdefdb['fqdnblocklist']
-        attackers=mozdefdb['attackers']
         # ensure indexes
         fqdnblocklist.create_index([('dateExpiring',-1)])
 
@@ -148,9 +147,6 @@ def initConfig():
 
     # Category to choose
     options.category = getConfig('category', 'bruteforcer', options.configfile)
-
-    # Max days to look back for attackers
-    #options.attackerage = getConfig('attackerage',90,options.configfile)
 
     # Days after expiration that we purge an fqdnblocklist entry (from the ui, they don't end up in the export after expiring)
     options.expireage = getConfig('expireage',1,options.configfile)

--- a/cron/createFDQNBlockList.py
+++ b/cron/createFDQNBlockList.py
@@ -61,44 +61,6 @@ def isFQDN(fqdn):
     except:
         return False
 
-# pretty sure this isn't relevant in an FDQN context
-# TODO: be sure of this before removing fully
-# def aggregateAttackerIPs(attackers):
-#     iplist = []
-
-#     # Set the attacker age timestamp
-#     attackerage = datetime.now() - timedelta(days=options.attackerage)
-
-#     ips = attackers.aggregate([
-#         {"$sort": {"lastseentimestamp": -1}},
-#         {"$match": {"category": options.category}},
-#         {"$match": {"lastseentimestamp": {"$gte": attackerage}}},
-#         {"$match": {"indicators.ipv4address": {"$exists": True}}},
-#         {"$group": {"_id": {"ipv4address": "$indicators.ipv4address"}}},
-#         {"$unwind": "$_id.ipv4address"},
-#         {"$limit": options.iplimit}
-#     ])
-
-#     for i in ips:
-#         whitelisted = False
-#         logger.debug('working {0}'.format(i))
-#         ip = i['_id']['ipv4address']
-#         ipcidr=netaddr.IPNetwork(ip)
-#         if not ipcidr.ip.is_loopback() and not ipcidr.ip.is_private() and not ipcidr.ip.is_reserved():
-#             for whitelist_range in options.ipwhitelist:
-#                 whitelist_network = netaddr.IPNetwork(whitelist_range)
-#                 if ipcidr in whitelist_network:
-#                     logger.debug(str(ipcidr) + " is whitelisted as part of " + str(whitelist_network))
-#                     whitelisted = True
-
-#             #strip any host bits 192.168.10/24 -> 192.168.0/24
-#             ipcidrnet=str(ipcidr.cidr)
-#             if ipcidrnet not in iplist and not whitelisted:
-#                 iplist.append(ipcidrnet)
-#         else:
-#             logger.debug('invalid:' + ip)
-#     return iplist
-
 def parse_fqdn_whitelist(fqdn_whitelist_location):
     fqdns = []
     with open(fqdn_whitelist_location, "r") as text_file:
@@ -119,17 +81,6 @@ def main():
         attackers=mozdefdb['attackers']
         # ensure indexes
         fqdnblocklist.create_index([('dateExpiring',-1)])
-
-        # TODO: determine if this is relevant in this context
-        # attackers.create_index([('lastseentimestamp',-1)])
-        # attackers.create_index([('category',1)])
-
-        # First, gather IP addresses from recent attackers and add to the block list
-        # attackerIPList = aggregateAttackerIPs(attackers)
-
-        # add attacker IPs to the blocklist
-        # first delete ones we've created from an attacker
-        # ipblocklist.delete_many({'creator': 'mozdef','reference':'attacker'})
 
         # delete any that expired
         fqdnblocklist.delete_many({'dateExpiring': {"$lte": datetime.utcnow()-timedelta(days=options.expireage)}})

--- a/cron/createFDQNBlockList.py
+++ b/cron/createFDQNBlockList.py
@@ -8,7 +8,6 @@
 import boto
 import boto.s3
 import logging
-import netaddr
 import random
 import re
 import sys
@@ -49,12 +48,8 @@ def genMeteorID():
 def isFQDN(fqdn):
     try:
         # We could resolve FQDNs here, but that could tip our hand and it's
-        # possible us investigating could trigger other alerts.  As such,
-        # validation will consist of making sure we have a dot noted string
-        #with two or more tokens
-        # Positive Example: example.com (2 tokens, 'example' and 'com' == valid)
-        # Positive Example: foo.example.com (3 tokens, 'example' and 'com' == valid)
-        # Negative Example: com (1 token, 'com' == invalid)
+        # possible us investigating could trigger other alerts.
+        # validate using the regex from https://github.com/yolothreat/utilitybelt
         fqdn_re = re.compile('(?=^.{4,255}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)', re.I | re.S | re.M)
         return bool(re.match(fqdn_re,fqdn))
     except:

--- a/cron/createFQDNBlockList.conf
+++ b/cron/createFQDNBlockList.conf
@@ -1,0 +1,9 @@
+[options]
+mongoport = 3002
+outputfile = /opt/mozdef/envs/mozdef/static/fqdnblocklist.txt
+fqdn_whitelist_file = /opt/mozdef/envs/mozdef/static/fqdnlist.txt
+aws_access_key_id = <add_aws_access_key_id>
+aws_secret_access_key = <add_aws_secret_access_key>
+aws_bucket_name = <add_aws_bucket_name>
+aws_document_key_name = fqdnblocklist
+iplimit = 3000

--- a/cron/createFQDNBlockList.sh
+++ b/cron/createFQDNBlockList.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+
+source  /opt/mozdef/envs/mozdef/bin/activate
+/opt/mozdef/envs/mozdef/cron/createFQDNBlockList.py -c /opt/mozdef/envs/mozdef/cron/createFQDNBlockList.conf
+

--- a/meteor/app/client/blockFDQN.js
+++ b/meteor/app/client/blockFDQN.js
@@ -11,7 +11,7 @@ if (Meteor.isClient) {
         $('#fqdn')[0].value = Session.get('blockFQDN');
     };
 
-    Template.blockFQDN.events({
+    Template.blockFQDNform.events({
         "submit form": function(event, template) {
             event.preventDefault();
             formobj=formToObject("#blockFQDN :input");

--- a/meteor/app/client/blockFDQN.js
+++ b/meteor/app/client/blockFDQN.js
@@ -1,0 +1,63 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+Copyright (c) 2014 Mozilla Corporation
+ */
+
+if (Meteor.isClient) {
+
+    Template.blockIPform.rendered = function() {
+        $('#fqdn')[0].value = Session.get('blockFQDN');
+    };
+
+    Template.blockFQDN.events({
+        "submit form": function(event, template) {
+            event.preventDefault();
+            formobj=formToObject("#blockFQDN :input");
+            formobj.push({userid:Meteor.user().profile.email});
+            Meteor.call('blockfqdn',formobj,
+                onResultReceived = function(err,result){
+                    if (typeof err == 'undefined') {
+                        //console.log(result);
+                        if ( result == true){
+                            Session.set('displayMessage','blocked & successfully ');
+                        }else{
+                            Session.set('errorMessage','block failed, returned & ' + JSON.stringify(result) );
+                        }
+                    }else{
+                        Session.set('errorMessage','block failed & ' + JSON.stringify(err));
+                    }
+                });
+            Router.go('/fqdnblocklist');
+        }
+    });
+
+    Template.blockFQDNModal.rendered = function(){
+        Deps.autorun(function() {
+            $('#fdqn')[0].value = Session.get('blockFQDN');
+        }); //end deps.autorun
+    };
+
+    Template.blockFQDNModal.events({
+        "submit form": function(event, template) {
+            event.preventDefault();
+            formobj=formToObject("#blockFQDNform :input");
+            formobj.push({userid:Meteor.user().profile.email});
+            Meteor.call('blockfqdn',formobj,
+                onResultReceived = function(err,result){
+                    if (typeof err == 'undefined') {
+                        //console.log(result);
+                        if ( result == true){
+                            Session.set('displayMessage','blocked & successfully ');
+                        }else{
+                            Session.set('errorMessage','block failed, returned & ' + JSON.stringify(result) );
+                        }
+                    }else{
+                        Session.set('errorMessage','block failed & ' + JSON.stringify(err));
+                    }
+                });
+            $('#modalBlockFQDNWindow').modal('hide')
+        }
+    });
+}

--- a/meteor/app/client/blockFDQN.js
+++ b/meteor/app/client/blockFDQN.js
@@ -35,7 +35,7 @@ if (Meteor.isClient) {
 
     Template.blockFQDNModal.rendered = function(){
         Deps.autorun(function() {
-            $('#fdqn')[0].value = Session.get('blockFQDN');
+            $('#fqdn')[0].value = Session.get('blockFQDN');
         }); //end deps.autorun
     };
 

--- a/meteor/app/client/blockFDQN.js
+++ b/meteor/app/client/blockFDQN.js
@@ -7,7 +7,7 @@ Copyright (c) 2014 Mozilla Corporation
 
 if (Meteor.isClient) {
 
-    Template.blockIPform.rendered = function() {
+    Template.blockFQDNform.rendered = function() {
         $('#fqdn')[0].value = Session.get('blockFQDN');
     };
 

--- a/meteor/app/client/blockFQDN.html
+++ b/meteor/app/client/blockFQDN.html
@@ -1,0 +1,166 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+Copyright (c) 2014 Mozilla Corporation
+-->
+
+<!--block FQDN form -->
+<template name="blockFQDNform">
+    <form id="blockFQDNform" class="form-horizontal" style="margin: 0px 30% 20px;">
+        <legend>Block FQDN</legend>
+        <fieldset>
+            <!-- FQDN (Full Qualified Domain Name) -->
+            <div class="control-group">
+              <label class="control-label" for="fqdn">Fully Qualified Domain Name (FQDN)</label>
+              <div class="controls">
+                <input id="fqdn" name="fqdn" class="form-control" type="text" required>
+              </div>
+            </div>
+            <!-- Duration -->
+            <div class="control-group">
+              <label class="control-label" for="duration">Duration</label>
+              <div class="controls">
+                <select id="duration" name="duration" class="form-control">
+                  <option value='1hr' selected>1 hour</option>
+                  <option value='12hr'>12 hours</option>
+                  <option value='1d'>1 day</option>
+                  <option value='2d'>2 days</option>
+                  <option value='3d'>3 days</option>
+                  <option value='1w'>1 week</option>
+                  <option value='30d'>30 days</option>
+                </select>
+              </div>
+            </div>
+            <!-- Comment -->
+            <div class="control-group">
+                <label class="control-label" for="comment">Comment</label>
+                <div class="controls">
+                    <input id="comment" name="comment" class="input-xlarge" type="text">
+                </div>
+            </div>
+
+            <div class="control-group">
+                <label class="control-label" for="referenceid">Reference ID</label>
+                <div class="controls">
+                    <input id="referenceid" name="referenceid" class="form-control" type="text" placeholder="optional">
+                </div>
+            </div>
+            <!--plugins-->
+            <div class="panel panel-primary">
+                <div class="panel-heading">
+                    <h3 class="panel-title">Plugins:</h3>
+                </div>
+                <div class="panel-body">
+                    {{#each pluginsForEndPoint "blockfqdn"}}
+
+                    <div class="form-group">
+                            <div class="col-xs-8 checkbox">
+                                <label>
+                                    <input type="checkbox"  name="{{name}}">{{name}}: ( {{description}} )
+                                </label>
+                            </div>
+                    </div>
+                    {{/each}}
+                </div>
+            </div>
+            <!-- Button -->
+            <div class="control-group">
+              <label class="control-label" for="submit"></label>
+              <div class="controls">
+                <button id="submit" type="submit" name="submit" class="btn btn-danger submit">Block!</button>
+              </div>
+            </div>
+        </fieldset>
+    </form>
+</template>
+
+
+<template name="blockFQDNModal">
+    <style>
+    .modal-body .row {
+        color: black;
+    }
+    </style>
+    <div class="modal fade" id="modalBlockFQDNWindow">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                   <button type="button" class="close" data-dismiss="modal">&times;</button>
+                   <h4>Block IP</h4>
+                </div>
+                <div class="modal-body">
+                    <form id="blockFQDNform" class="form-horizontal" style="margin: 0px 5%;">
+                            <!-- FQDN (Full Qualified Domain Name) -->
+                            <div class="form-group">
+                              <label class="control-label" for="fqdn">Fully Qualified Domain Name (FQDN)</label>
+                              <div class="controls">
+                                <input id="fqdn" name="fqdn" class="form-control" type="text" required>
+                              </div>
+                            </div>
+                            <!-- Duration -->
+                            <div class="form-group">
+                              <label class="control-label" for="duration">Duration</label>
+                              <div class="controls">
+                                <select id="duration" name="duration" class="form-control">
+                                  <option value='1hr' selected>1 hour</option>
+                                  <option value='12hr'>12 hours</option>
+                                  <option value='1d'>1 day</option>
+                                  <option value='2d'>2 days</option>
+                                  <option value='3d'>3 days</option>
+                                  <option value='1w'>1 week</option>
+                                  <option value='30d'>30 days</option>
+                                </select>
+                              </div>
+                            </div>
+                            <!-- Comment -->
+                            <div class="form-group">
+                                <label class="control-label" for="comment">Comment</label>
+                                <div class="controls">
+                                    <input id="comment" name="comment" class="form-control" type="text">
+                                </div>
+                            </div>
+
+                            <div class="form-group">
+                                <label class="control-label" for="referenceid">Reference ID</label>
+                                <div class="controls">
+                                    <input id="referenceid" name="referenceid" class="form-control" type="text" placeholder="optional" >
+                                </div>
+                            </div>
+
+                            <!--plugins-->
+                            <div class="panel panel-primary">
+                                <div class="panel-heading">
+                                  <h3 class="panel-title">Plugins:</h3>
+                                </div>
+                                <div class="panel-body">
+                                    {{#each pluginsForEndPoint "blockfqdn"}}
+
+                                    <div class="form-group">
+                                            <div class="col-xs-8 checkbox">
+                                                <label>
+                                                    <input type="checkbox"  name="{{name}}">{{name}}: ( {{description}} )
+                                                </label>
+                                            </div>
+                                    </div>
+                                    {{/each}}
+                                </div>
+                            </div>
+
+
+                            <!-- Button -->
+                            <div class="form-group">
+                              <label class="control-label" for="submit"></label>
+                              <div class="controls">
+                                <button id="submit" type="submit" name="submit" class="btn btn-danger submit">Block!</button>
+                              </div>
+                            </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                  <a href="#" class="btn btn-primary" data-dismiss="modal">Close</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/meteor/app/client/blockFQDN.html
+++ b/meteor/app/client/blockFQDN.html
@@ -87,7 +87,7 @@ Copyright (c) 2014 Mozilla Corporation
             <div class="modal-content">
                 <div class="modal-header">
                    <button type="button" class="close" data-dismiss="modal">&times;</button>
-                   <h4>Block IP</h4>
+                   <h4>Block FQDN</h4>
                 </div>
                 <div class="modal-body">
                     <form id="blockFQDNform" class="form-horizontal" style="margin: 0px 5%;">

--- a/meteor/app/client/fqdnBlocklistTable.html
+++ b/meteor/app/client/fqdnBlocklistTable.html
@@ -23,8 +23,8 @@ Copyright (c) 2014 Mozilla Corporation
                     </tr>
                 </thead>
                 <tbody>
-                {{#each ipblock}}
-                    {{>each_ipblock}}
+                {{#each fqdnblock}}
+                    {{>each_fqdnblock}}
                 {{/each}}
                 </tbody>
             </table>

--- a/meteor/app/client/fqdnBlocklistTable.html
+++ b/meteor/app/client/fqdnBlocklistTable.html
@@ -5,7 +5,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Copyright (c) 2014 Mozilla Corporation
 -->
 
-<!--a striped table of our ip blocks-->
+<!--a striped table of our fqdn blocks-->
 <template name="fqdnblocklist">
     <div class="fqdnblocklist container">
         <div class="fluid center">
@@ -32,8 +32,8 @@ Copyright (c) 2014 Mozilla Corporation
     </div>
 </template>
 
-<!--each individual ipblock -->
-<template name="each_ipblock">
+<!--each individual fqdnblock -->
+<template name="each_fqdnblock">
 
     <tr class="tooltip-wrapper info-row" title="{{creator}} at {{dateAdded}}" data-toggle="tooltip">
         <td></td>
@@ -46,7 +46,7 @@ Copyright (c) 2014 Mozilla Corporation
         <td>
             <button class="btn btn-xs btn-warning" data-toggle="collapse" data-target="#delete{{_id}}">arm delete</button>
             <div id="delete{{_id}}" class="collapse">
-                <button class="btn btn-xs btn-danger fqdnblockdelete" data-ipblockid={{_id}}>delete</button>
+                <button class="btn btn-xs btn-danger fqdnblockdelete" data-fqdnblockid={{_id}}>delete</button>
             </div>
         </td>
     </tr>

--- a/meteor/app/client/fqdnBlocklistTable.html
+++ b/meteor/app/client/fqdnBlocklistTable.html
@@ -1,0 +1,54 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+Copyright (c) 2014 Mozilla Corporation
+-->
+
+<!--a striped table of our ip blocks-->
+<template name="fqdnblocklist">
+    <div class="fqdnblocklist container">
+        <div class="fluid center">
+            <table class="table table-striped table-hover table-condensed">
+                <caption><p class="lead">FQDN Blocklist</p></caption>
+                <thead>
+                    <tr>
+                        <td><button class="btn btn-xs btn-default fqdnblockadd">add</button></td>
+                        <td>FQDN</td>
+                        <td>Added</td>
+                        <td>Expiring</td>
+                        <td>Comment</td>
+                        <td>By</td>
+                        <td>Reference</td>
+                    </tr>
+                </thead>
+                <tbody>
+                {{#each ipblock}}
+                    {{>each_ipblock}}
+                {{/each}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</template>
+
+<!--each individual ipblock -->
+<template name="each_ipblock">
+
+    <tr class="tooltip-wrapper info-row" title="{{creator}} at {{dateAdded}}" data-toggle="tooltip">
+        <td></td>
+        <td>{{{fqdn}}}</td>
+        <td>{{dateAdded}}</td>
+        <td>{{dateExpiring}}</td>
+        <td>{{comment}}</td>
+        <td>{{creator}}</td>
+        <td>{{reference}}</td>
+        <td>
+            <button class="btn btn-xs btn-warning" data-toggle="collapse" data-target="#delete{{_id}}">arm delete</button>
+            <div id="delete{{_id}}" class="collapse">
+                <button class="btn btn-xs btn-danger fqdnblockdelete" data-ipblockid={{_id}}>delete</button>
+            </div>
+        </td>
+    </tr>
+
+</template>

--- a/meteor/app/client/fqdnBlocklistTable.js
+++ b/meteor/app/client/fqdnBlocklistTable.js
@@ -16,7 +16,6 @@ if (Meteor.isClient) {
         }
     });
 
-    //select an incident for editing
     Template.fqdnblocklist.events({
         "click .fqdnblockadd": function(e,t){
             //clear any leftover fqdn session val

--- a/meteor/app/client/fqdnBlocklistTable.js
+++ b/meteor/app/client/fqdnBlocklistTable.js
@@ -1,0 +1,41 @@
+ /*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+Copyright (c) 2014 Mozilla Corporation
+*/
+
+if (Meteor.isClient) {
+
+    //return all items
+    Template.fqdnblocklist.helpers({
+        fqdnblock: function () {
+            return fqdnblocklist.find({},{
+                                   sort: {dateExpiring: -1}
+                                });
+        }
+    });
+
+    //select an incident for editing
+    Template.fqdnblocklist.events({
+        "click .fqdnblockadd": function(e,t){
+            //clear any leftover fqdn session val
+            Session.set('blockFQDN','');
+            $('#modalBlockFQDNWindow').modal();
+        },
+
+        "click .fqdnblockdelete": function(e,t){
+            fqdnblocklist.remove(this._id);
+            // TODO: sort out what I need instead of address in this context
+            Session.set('displayMessage','Deleted fqdnblock for & ' + this.fqdn);
+        }
+    });
+
+    Template.fqdnblocklist.rendered = function(){
+        Deps.autorun(function() {
+            Meteor.subscribe("fqdnblocklist");
+        });
+
+    };
+
+}

--- a/meteor/app/client/menu.html
+++ b/meteor/app/client/menu.html
@@ -24,6 +24,7 @@ Copyright (c) 2014 Mozilla Corporation
                 <li><a href="/alerts/">Alerts</a>
                     <ul>
                         <li class="first"><a href="/ipblocklist">ip blocklist</a></li>
+                        <li class="first"><a href="/fqdnblocklist">fqdn blocklist</a></li>
                     </ul>
                 </li>
                 <li><a href="/investigations">Investigations</a>

--- a/meteor/app/client/mozdef.js
+++ b/meteor/app/client/mozdef.js
@@ -16,6 +16,8 @@ if (Meteor.isClient) {
         Session.set('alertsrecordlimit',100);
         Session.set('attackerlimit','10');
         Session.set('attackersearchIP','');
+        Session.set('blockIPipaddress','');
+        Session.set('blockFQDN','');
         getAllPlugins();
 
         // Sends us to register our login handler

--- a/meteor/app/lib/collections.js
+++ b/meteor/app/lib/collections.js
@@ -22,6 +22,8 @@ Copyright (c) 2014 Mozilla Corporation
     actions = new Meteor.Collection("actions");
     userActivity = new Meteor.Collection("userActivity");
     ipblocklist = new Meteor.Collection("ipblocklist");
+    fqdnblocklist = new Meteor.Collection("fqdnblocklist");
+
 
 if (Meteor.isServer) {
     //Publishing setups
@@ -272,6 +274,10 @@ if (Meteor.isServer) {
         return ipblocklist.find({},{limit:0});
     })
 
+    Meteor.publish("fqdnblocklist", function () {
+        return fqdnblocklist.find({},{limit:0});
+    })
+
    //access rules from clients
    //barebones to allow you to specify rules
 
@@ -333,20 +339,37 @@ if (Meteor.isServer) {
     });
 
     ipblocklist.allow({
-        insert: function (userId, doc) {
-          // the user must be logged in
-          return (userId);
-        },
-        update: function (userId, doc, fields, modifier) {
-          // the user must be logged in
-          return (userId);
-        },
-        remove: function (userId, doc) {
-          // the user must be logged in
-          return (userId);
-        },
-        fetch: ['creator']
-      });
+      insert: function (userId, doc) {
+        // the user must be logged in
+        return (userId);
+      },
+      update: function (userId, doc, fields, modifier) {
+        // the user must be logged in
+        return (userId);
+      },
+      remove: function (userId, doc) {
+        // the user must be logged in
+        return (userId);
+      },
+      fetch: ['creator']
+    });
+
+    fqdnblocklist.allow({
+      insert: function (userId, doc) {
+        // the user must be logged in
+        return (userId);
+      },
+      update: function (userId, doc, fields, modifier) {
+        // the user must be logged in
+        return (userId);
+      },
+      remove: function (userId, doc) {
+        // the user must be logged in
+        return (userId);
+      },
+      fetch: ['creator']
+    });
+
 };
 
 if (Meteor.isClient) {

--- a/meteor/app/router/router.js
+++ b/meteor/app/router/router.js
@@ -48,6 +48,11 @@ Router.map(function () {
         layoutTemplate: 'layout'
     });
 
+    this.route('fqdnblocklist', {
+        path: '/fqdnblocklist',
+        template: 'fqdnblocklist',
+        layoutTemplate: 'layout'
+    });
 
     this.route('investigations', {
         path: '/investigations',
@@ -151,6 +156,16 @@ Router.map(function () {
         },
         layoutTemplate: 'layout'
     });
+
+    this.route('blockfqdn', {
+        path: '/blockfqdn/:_fqdn',
+        template: 'blockFQDNform',
+        data: function() {
+            Session.set('blockFQDN', this.params._fqdn);
+        },
+        layoutTemplate: 'layout'
+    });
+
 
     this.route('ipwhois', {
         path: '/ipwhois/:_ipaddress',

--- a/meteor/app/server/methods.js
+++ b/meteor/app/server/methods.js
@@ -59,14 +59,23 @@ if (Meteor.isServer) {
     }
 
     function blockFQDN(formobj) {
-        var blockFQDNRequest = HTTP.post(mozdef.rootAPI + '/blockfqdn', {data: formobj});
+        try{
+            var blockFQDNRequest = HTTP.post(mozdef.rootAPI + '/blockfqdn', {data: formobj});
 
-        if (blockFQDNRequest.statusCode==200) {
-            console.log(JSON.stringify(formobj) + ' successfully sent to ' + mozdef.rootAPI);
-            return true;
-        } else {
-            console.log("Could not send to "+ mozdef.rootAPI + '/blockfqdn ' + JSON.stringify(formobj) );
-            return blockFQDNRequest;
+            if (blockFQDNRequest.statusCode==200) {
+                console.log(JSON.stringify(formobj) + ' successfully sent to ' + mozdef.rootAPI);
+                return true;
+            }
+        }catch (e) {
+            console.log("Error posting to "+ mozdef.rootAPI + '/blockfqdn ' + JSON.stringify(formobj) );
+            console.log(e)
+            if ( e.response.statusCode == 400 ){
+                // rest API set a reason in content
+                console.log(e.response.content);
+                return e.response.content;
+            }else{
+                return e;
+            }
         }
     }
 

--- a/meteor/app/server/methods.js
+++ b/meteor/app/server/methods.js
@@ -57,6 +57,18 @@ if (Meteor.isServer) {
         }
     }
 
+    function blockFQDN(formobj) {
+        var blockFQDNRequest = HTTP.post(mozdef.rootAPI + '/blockfqdn', {data: formobj});
+
+        if (blockFQDNRequest.statusCode==200) {
+            console.log(JSON.stringify(formobj) + ' successfully sent to ' + mozdef.rootAPI);
+            return true;
+        } else {
+            console.log("Could not send to "+ mozdef.rootAPI + '/blockfqdn ' + JSON.stringify(formobj) );
+            return blockFQDNRequest;
+        }
+    }
+
     function ipwhois(ipaddress){
         //console.log('Posting ' + ipaddress + 'to ' + mozdef.rootAPI + '/ipwhois/');
         var ipwhoisResponse = HTTP.post(mozdef.rootAPI + '/ipwhois/',{data: {'ipaddress':ipaddress}});

--- a/meteor/app/server/methods.js
+++ b/meteor/app/server/methods.js
@@ -11,6 +11,7 @@ if (Meteor.isServer) {
         'saySomething': saySomething,
         'loadKibanaDashboards': loadKibanaDashboards,
         'blockip': blockIP,
+        'blockfqdn': blockFQDN,
         'ipwhois': ipwhois,
         'ipdshield': ipdshield,
         'ipintel': ipintel,

--- a/meteor/mozdef.html
+++ b/meteor/mozdef.html
@@ -45,6 +45,7 @@ Copyright (c) 2014 Mozilla Corporation
 {{>dshieldmodal}}
 {{>blockIPModal}}
 {{>intelmodal}}
+{{>blockFQDNModal}}
 
 </template>
 

--- a/rest/index.py
+++ b/rest/index.py
@@ -123,6 +123,13 @@ def index():
     sendMessgeToPlugins(request, response, 'blockip')
     return response
 
+@post('/blockfqdn', methods=['POST'])
+@post('/blockfqdn/', methods=['POST'])
+@enable_cors
+def index():
+    '''will receive a call to block an ip address'''
+    sendMessgeToPlugins(request, response, 'blockfqdn')
+    return response
 
 @post('/ipwhois', methods=['POST'])
 @post('/ipwhois/', methods=['POST'])

--- a/rest/plugins/fqdnblocklist.conf
+++ b/rest/plugins/fqdnblocklist.conf
@@ -1,0 +1,4 @@
+[options]
+mongohost=mongodb
+mongoport=3002
+fqdn_whitelist_file=/dev/null

--- a/rest/plugins/fqdnblocklist.py
+++ b/rest/plugins/fqdnblocklist.py
@@ -15,12 +15,8 @@ from pymongo import MongoClient
 def isFQDN(fqdn):
     try:
         # We could resolve FQDNs here, but that could tip our hand and it's
-        # possible us investigating could trigger other alerts.  As such,
-        # validation will consist of making sure we have a dot noted string
-        #with two or more tokens
-        # Positive Example: example.com (2 tokens, 'example' and 'com' == valid)
-        # Positive Example: foo.example.com (3 tokens, 'example' and 'com' == valid)
-        # Negative Example: com (1 token, 'com' == invalid)
+        # possible us investigating could trigger other alerts.
+        # validate using the regex from https://github.com/yolothreat/utilitybelt
         fqdn_re = re.compile('(?=^.{4,255}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)', re.I | re.S | re.M)
         return bool(re.match(fqdn_re,fqdn))
     except:

--- a/rest/plugins/fqdnblocklist.py
+++ b/rest/plugins/fqdnblocklist.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-import netaddr
 import os
 import random
 import requests

--- a/rest/plugins/fqdnblocklist.py
+++ b/rest/plugins/fqdnblocklist.py
@@ -14,14 +14,14 @@ from pymongo import MongoClient
 
 def isFQDN(fqdn):
     try:
-        # We could resolve FQDNs here, but that could tip our hand and it's 
+        # We could resolve FQDNs here, but that could tip our hand and it's
         # possible us investigating could trigger other alerts.  As such,
         # validation will consist of making sure we have a dot noted string
         #with two or more tokens
         # Positive Example: example.com (2 tokens, 'example' and 'com' == valid)
         # Positive Example: foo.example.com (3 tokens, 'example' and 'com' == valid)
         # Negative Example: com (1 token, 'com' == invalid)
-        if '.' in fqdn and len(ip.split('.'))>=2:
+        if '.' in fqdn and len(fqdn.split('.'))>=2:
             return True
         else:
             return False
@@ -65,7 +65,7 @@ class message(object):
             sys.stdout.write('found conf file {0}\n'.format(self.configfile))
         self.initConfiguration()
 
-    def parse_fqdn_whitelist(self, network_whitelist_location):
+    def parse_fqdn_whitelist(self, fqdn_whitelist_location):
         fqdns = []
         with open(fqdn_whitelist_location, "r") as text_file:
             for line in text_file:
@@ -95,7 +95,7 @@ class message(object):
             self.configfile)
 
         # FQDN whitelist as a comma separted list of example.com or foo.bar.com style names
-        self.options.network_whitelist_file = getConfig('network_whitelist_file', '/dev/null', self.configfile)
+        self.options.fqdn_whitelist_file = getConfig('fqdn_whitelist_file', '/dev/null', self.configfile)
 
         # optional statuspage.io integration
         self.options.statuspage_api_key = getConfig(
@@ -133,7 +133,7 @@ class message(object):
             if isFQDN(fqdn):
 
                 # already in the table?
-                fqdnblock = fqdnblocklist.find_one({'ipaddress': fqdn})
+                fqdnblock = fqdnblocklist.find_one({'fqdn': fqdn})
                 if fqdnblock is None:
                     # insert
                     fqdnblock= dict()
@@ -203,8 +203,8 @@ class message(object):
         '''
         response.headers['X-PLUGIN'] = self.description
 
-        # Refresh the ip network list each time we get a message
-        self.options.ipwhitelist = self.parse_fqdn_whitelist(self.options.fqdn_whitelist_file)
+        # Refresh the whitelist each time we get a message
+        self.options.fqdnwhitelist = self.parse_fqdn_whitelist(self.options.fqdn_whitelist_file)
 
         fqdn = None
         comment = None
@@ -232,7 +232,6 @@ class message(object):
                     userid = i.values()[0]
 
             if blockfqdn and fqdn is not None:
-                # figure out the CIDR mask
                 if isFQDN(fqdn):
                         whitelisted = False
                         for whitelist_fqdn in self.options.fqdnwhitelist:

--- a/rest/plugins/fqdnblocklist.py
+++ b/rest/plugins/fqdnblocklist.py
@@ -247,7 +247,12 @@ class message(object):
                             sys.stdout.write('added {0} to blocklist\n'.format(fqdn))
                         else:
                             sys.stdout.write('not adding {0} to blocklist, it was found in whitelist\n'.format(fqdn))
+                else:
+                    sys.stdout.write('not adding {0} to blocklist, invalid fqdn\n'.format(fqdn))
+                    response.status = "400 invalid FQDN"
+                    response.body = "invalid FQDN"
         except Exception as e:
             sys.stderr.write('Error handling request.json %r \n'% (e))
+            response.status = "500"
 
         return (request, response)

--- a/rest/plugins/fqdnblocklist.py
+++ b/rest/plugins/fqdnblocklist.py
@@ -7,6 +7,7 @@ import netaddr
 import os
 import random
 import requests
+import re
 import sys
 from configlib import getConfig, OptionParser
 from datetime import datetime, timedelta
@@ -21,10 +22,8 @@ def isFQDN(fqdn):
         # Positive Example: example.com (2 tokens, 'example' and 'com' == valid)
         # Positive Example: foo.example.com (3 tokens, 'example' and 'com' == valid)
         # Negative Example: com (1 token, 'com' == invalid)
-        if '.' in fqdn and len(fqdn.split('.'))>=2:
-            return True
-        else:
-            return False
+        fqdn_re = re.compile('(?=^.{4,255}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)', re.I | re.S | re.M)
+        return bool(re.match(fqdn_re,fqdn))
     except:
         return False
 

--- a/rest/plugins/fqdnblocklist.py
+++ b/rest/plugins/fqdnblocklist.py
@@ -1,0 +1,255 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+
+import netaddr
+import os
+import random
+import requests
+import sys
+from configlib import getConfig, OptionParser
+from datetime import datetime, timedelta
+from pymongo import MongoClient
+
+def isFQDN(fqdn):
+    try:
+        # We could resolve FQDNs here, but that could tip our hand and it's 
+        # possible us investigating could trigger other alerts.  As such,
+        # validation will consist of making sure we have a dot noted string
+        #with two or more tokens
+        # Positive Example: example.com (2 tokens, 'example' and 'com' == valid)
+        # Positive Example: foo.example.com (3 tokens, 'example' and 'com' == valid)
+        # Negative Example: com (1 token, 'com' == invalid)
+        if '.' in fqdn and len(ip.split('.'))>=2:
+            return True
+        else:
+            return False
+    except:
+        return False
+
+def genMeteorID():
+    return('%024x' % random.randrange(16**24))
+
+class message(object):
+    def __init__(self):
+        '''register our criteria for being passed a message
+           as a list of lower case strings to match with an rest endpoint
+           (i.e. blockip matches /blockip)
+           set the priority if you have a preference for order of plugins
+           0 goes first, 100 is assumed/default if not sent
+
+           Plugins will register in Meteor with attributes:
+           name: (as below)
+           description: (as below)
+           priority: (as below)
+           file: "plugins.filename" where filename.py is the plugin code.
+
+           Plugin gets sent main rest options as:
+           self.restoptions
+           self.restoptions['configfile'] will be the .conf file
+           used by the restapi's index.py file.
+
+        '''
+
+        self.registration = ['blockfqdn']
+        self.priority = 10
+        self.name = "FQDNBlockList"
+        self.description = "FQDN Block LIst"
+
+        # set my own conf file
+        # relative path to the rest index.py file
+        self.configfile = './plugins/fqdnblocklist.conf'
+        self.options = None
+        if os.path.exists(self.configfile):
+            sys.stdout.write('found conf file {0}\n'.format(self.configfile))
+        self.initConfiguration()
+
+    def parse_fqdn_whitelist(self, network_whitelist_location):
+        fqdns = []
+        with open(fqdn_whitelist_location, "r") as text_file:
+            for line in text_file:
+                line=line.strip().strip("'").strip('"')
+                if isFQDN(line):
+                    fqdns.append(line)
+        return fqdns
+
+    def initConfiguration(self):
+        myparser = OptionParser()
+        # setup self.options by sending empty list [] to parse_args
+        (self.options, args) = myparser.parse_args([])
+
+        # fill self.options with plugin-specific options
+
+        # options for your custom/internal ip blocking service
+        # mozilla's is called banhammer
+        # and uses an intermediary mysql DB
+        # here we set credentials
+        self.options.mongohost = getConfig(
+            'mongohost',
+            'localhost',
+            self.configfile)
+        self.options.mongoport = getConfig(
+            'mongoport',
+            3001,
+            self.configfile)
+
+        # FQDN whitelist as a comma separted list of example.com or foo.bar.com style names
+        self.options.network_whitelist_file = getConfig('network_whitelist_file', '/dev/null', self.configfile)
+
+        # optional statuspage.io integration
+        self.options.statuspage_api_key = getConfig(
+            'statuspage_api_key',
+            '',
+            self.configfile)
+        self.options.statuspage_page_id = getConfig(
+            'statuspage_page_id',
+            '',
+            self.configfile)
+        self.options.statuspage_url = 'https://api.statuspage.io/v1/pages/{0}/incidents.json'.format(
+            self.options.statuspage_page_id)
+        self.options.statuspage_component_id = getConfig(
+            'statuspage_component_id',
+            '',
+            self.configfile)
+        self.options.statuspage_sub_component_id = getConfig(
+            'statuspage_sub_component_id',
+            '',
+            self.configfile)
+
+    def blockFQDN(self,
+                fqdn = None,
+                comment = None,
+                duration = None,
+                referenceID = None,
+                userID=None
+                ):
+        try:
+            # DB connection/table
+            mongoclient = MongoClient(self.options.mongohost, self.options.mongoport)
+            fqdnblocklist = mongoclient.meteor['fqdnblocklist']
+
+            # good data?
+            if isFQDN(fqdn):
+
+                # already in the table?
+                fqdnblock = fqdnblocklist.find_one({'ipaddress': fqdn})
+                if fqdnblock is None:
+                    # insert
+                    fqdnblock= dict()
+                    fqdnblock['_id'] = genMeteorID()
+                    fqdnblock['fqdn']= fqdn
+                    fqdnblock['dateAdded'] = datetime.utcnow()
+                    # Compute start and end dates
+                    # default
+                    end_date = datetime.utcnow() + timedelta(hours=1)
+                    if duration == '12hr':
+                        end_date = datetime.utcnow() + timedelta(hours=12)
+                    elif duration == '1d':
+                        end_date = datetime.utcnow() + timedelta(days=1)
+                    elif duration == '2d':
+                        end_date = datetime.utcnow() + timedelta(days=2)
+                    elif duration == '3d':
+                        end_date = datetime.utcnow() + timedelta(days=3)
+                    elif duration == '1w':
+                        end_date = datetime.utcnow() + timedelta(days=7)
+                    elif duration == '30d':
+                        end_date = datetime.utcnow() + timedelta(days=30)
+                    fqdnblock['dateExpiring'] = end_date
+                    fqdnblock['comment'] = comment
+                    fqdnblock['creator'] = userID
+                    fqdnblock['reference'] = referenceID
+                    ref=fqdnblocklist.insert(fqdnblock)
+                    sys.stdout.write('{0} written to db\n'.format(ref))
+                    sys.stdout.write('%s: added to the fqdnblocklist table\n' % (fqdn))
+
+                    # send to statuspage.io?
+                    if len(self.options.statuspage_api_key)>1:
+                        try:
+                            headers = {'Authorization': 'Oauth {0}'.format(self.options.statuspage_api_key)}
+                            # send the data as a form post per:
+                            # https://doers.statuspage.io/api/v1/incidents/#create-realtime
+                            post_data={
+                            'incident[name]' : 'block FQDN {}'.format(fqdn),
+                            'incident[status]' : 'resolved',
+                            'incident[impact_override]' : 'none',
+                            'incident[body]' : '{} initiated a block of FDQN {} until {}'.format(
+                                userID,
+                                fqdn,
+                                end_date.isoformat()),
+                            'incident[component_ids][]' : self.options.statuspage_sub_component_id,
+                            'incident[components][{0}]'.format(self.options.statuspage_component_id) : "operational"}
+                            response = requests.post(self.options.statuspage_url,
+                                                    headers=headers,
+                                                    data=post_data)
+                            if response.ok :
+                                sys.stdout.write('%s: notification sent to statuspage.io\n' % (fqdn))
+                            else:
+                                sys.stderr.write('%s: statuspage.io notification failed %s\n' % (fqdn,response.json()))
+                        except Exception as e:
+                            sys.stderr.write('Error while notifying statuspage.io for %s: %s\n' %(fqdn,e))
+                else:
+                    sys.stderr.write('%s: is already present in the fqdnblocklist table\n' % (fqdn))
+            else:
+                sys.stderr.write('%s: is not a valid fqdn\n' % (fqdn))
+        except Exception as e:
+            sys.stderr.write('Error while blocking %s: %s\n' % (fqdn, e))
+
+    def onMessage(self, request, response):
+        '''
+        request: http://bottlepy.org/docs/dev/api.html#the-request-object
+        response: http://bottlepy.org/docs/dev/api.html#the-response-object
+
+        '''
+        response.headers['X-PLUGIN'] = self.description
+
+        # Refresh the ip network list each time we get a message
+        self.options.ipwhitelist = self.parse_fqdn_whitelist(self.options.fqdn_whitelist_file)
+
+        fqdn = None
+        comment = None
+        duration = None
+        referenceID = None
+        userid = None
+        blockfqdn = False
+
+        # loop through the fields of the form
+        # and fill in our values
+        try:
+            for i in request.json:
+                # were we checked?
+                if self.name in i.keys():
+                    blockfqdn = i.values()[0]
+                if 'fqdn' in i.keys():
+                    fqdn = i.values()[0]
+                if 'duration' in i.keys():
+                    duration = i.values()[0]
+                if 'comment' in i.keys():
+                    comment = i.values()[0]
+                if 'referenceid' in i.keys():
+                    referenceID = i.values()[0]
+                if 'userid' in i.keys():
+                    userid = i.values()[0]
+
+            if blockfqdn and fqdn is not None:
+                # figure out the CIDR mask
+                if isFQDN(fqdn):
+                        whitelisted = False
+                        for whitelist_fqdn in self.options.fqdnwhitelist:
+                            if fqdn == whitelist_fqdn:
+                                whitelisted = True
+                                sys.stdout.write('{0} is whitelisted as part of {1}\n'.format(fqdn, whitelist_fqdn))
+
+                        if not whitelisted:
+                            self.blockFQDN(fqdn,
+                                         comment,
+                                         duration,
+                                         referenceID,
+                                         userid)
+                            sys.stdout.write('added {0} to blocklist\n'.format(fqdn))
+                        else:
+                            sys.stdout.write('not adding {0} to blocklist, it was found in whitelist\n'.format(fqdn))
+        except Exception as e:
+            sys.stderr.write('Error handling request.json %r \n'% (e))
+
+        return (request, response)


### PR DESCRIPTION
I'm not very "webby" in the context of developing web-pages, though I do like to break them.  Here's an attempt at cloning something we've already built for IP/network block lists and porting to work for FQDNs (Fully Qualified Domain Names).  The idea being that if a SPOC needs to respond to say block a phishing domain, they could drop into the UI and take decisive action to "add it to the FQDN blocklist" and that could be consumed by other services (see bug 1454672), like the proxy servers, DNS servers, and maybe even AWS security groups to protect our users and our services from said bad FQDN.

I've also marked this a WIP (Work In Progress) to start with since I'm starting with just modding code, getting some initial review, and I've not actually even tested this to make sure it doesn't immediately blow up.

If you're interested in helping in any way, please feel free to do so in whatever way you feel comfortable.