### PR TITLE
Add details.requestparameters.instanceType

### DIFF
--- a/mq/plugins/cloudtrail.py
+++ b/mq/plugins/cloudtrail.py
@@ -23,6 +23,7 @@ class message(object):
         # into a dict with a raw_value key as the string value
         self.modify_keys = [
             'details.requestparameters.iamInstanceProfile',
+            'details.requestparameters.instanceType',
             'details.requestparameters.attribute',
             'details.requestparameters.description',
             'details.requestparameters.filter',


### PR DESCRIPTION
Log errors say details.requestparameters.instanceType is sometimes an object:
"instanceType": {"value": "t2.medium"}}