### PR TITLE
Adding updated logrotate scripts for mozdef archival of old logs.

### DIFF
--- a/config/logrotate-mongod
+++ b/config/logrotate-mongod
@@ -1,5 +1,6 @@
 /var/log/mozdef/mongo/*.log
 {
+ su mozdef mozdef
  rotate 4
  weekly
  missingok
@@ -8,6 +9,7 @@
  delaycompress
  sharedscripts
  postrotate
+  mv /var/log/mozdef/mongo/*.gz /var/logarchive/mozdef/
   service rsyslog reload-or-restart > /dev/null
  endscript
 }

--- a/config/logrotate-mozdef
+++ b/config/logrotate-mozdef
@@ -8,6 +8,7 @@
  delaycompress
  sharedscripts
  postrotate
+  mv /var/log/mozdef/*.gz /var/logarchive/mozdef/
   service rsyslog reload-or-restart > /dev/null
  endscript
 }

--- a/config/logrotate-nginx
+++ b/config/logrotate-nginx
@@ -1,15 +1,18 @@
-/var/log/mozdef/nginx/*.error_log {
-        weekly
-        missingok
-        rotate 4
-        compress
-        delaycompress
-        notifempty
-        create 644 mozdef mozdef
-        sharedscripts
-        postrotate
-                if [ -f /var/run/nginx.pid ]; then
-                        kill -USR1 `cat /var/run/nginx.pid`
-                fi
-        endscript
+/var/log/mozdef/nginx/*.error_log 
+{
+    su mozdef mozdef
+    weekly
+    missingok
+    rotate 4
+    compress
+    delaycompress
+    notifempty
+    create 644 mozdef mozdef
+    sharedscripts
+    postrotate
+        mv /var/log/mozdef/nginx/*.gz /var/logarchive/mozdef/
+        if [ -f /var/run/nginx.pid ]; then
+             kill -USR1 `cat /var/run/nginx.pid`
+        fi
+    endscript
 }


### PR DESCRIPTION
This update to our logrotate scripts moves the archived logs out of the original log directory into an archive directory. I've also added the su directive for those directories rotated from that are owned by mozdef instead of root.