### PR TITLE
hostname field normalization phase I 

### DIFF
--- a/alerts/auditd_sftp.py
+++ b/alerts/auditd_sftp.py
@@ -34,9 +34,9 @@ class AlertSFTPEvent(AlertTask):
         username = 'unknown'
         directory = 'unknown'
         x = event['_source']
+        if 'hostname' in x:
+            srchost = x['hostname']
         if 'details' in x:
-            if 'hostname' in x['details']:
-                srchost = x['details']['hostname']
             if 'originaluser' in x['details']:
                 username = x['details']['originaluser']
             if 'cwd' in x['details']:

--- a/alerts/bruteforce_ssh.py
+++ b/alerts/bruteforce_ssh.py
@@ -42,7 +42,7 @@ class AlertBruteforceSsh(AlertTask):
         severity = 'NOTICE'
 
         summary = ('{0} ssh bruteforce attempts by {1}'.format(aggreg['count'], aggreg['value']))
-        hosts = self.mostCommon(aggreg['allevents'], '_source.details.hostname')
+        hosts = self.mostCommon(aggreg['allevents'], '_source.hostname')
         for i in hosts[:5]:
             summary += ' {0} ({1} hits)'.format(i[0], i[1])
 

--- a/alerts/duo_fail_open.py
+++ b/alerts/duo_fail_open.py
@@ -23,7 +23,7 @@ class AlertDuoFailOpen(AlertTask):
 
         # Search aggregations on field 'sourceipaddress', keep X samples of
         # events at most
-        self.searchEventsAggregated('details.hostname', samplesLimit=10)
+        self.searchEventsAggregated('hostname', samplesLimit=10)
         # alert when >= X matching events in an aggregation
         # in this case, always
         self.walkAggregations(threshold=1)

--- a/alerts/generic_alert_loader.py
+++ b/alerts/generic_alert_loader.py
@@ -139,14 +139,12 @@ class AlertGenericLoader(AlertTask):
         url = aggreg['config']['alert_url']
 
         # Find all affected hosts
-        # Normally, the hostname data is in e.details.hostname so try that first,
+        # Normally, the hostname data is in e.hostname so try that first,
         # but fall back to e.hostname if it is missing, or nothing at all if there's no hostname! ;-)
         hostnames = []
         for e in aggreg['events']:
             event_source = e['_source']
-            if 'details' in event_source and 'hostname' in event_source['details']:
-                hostnames.append(event_source['details']['hostname'])
-            elif 'hostname' in event_source:
+            if 'hostname' in event_source:
                 hostnames.append(event_source['hostname'])
 
         summary = '{} ({}): {}'.format(

--- a/alerts/lib/alerttask.py
+++ b/alerts/lib/alerttask.py
@@ -29,7 +29,7 @@ from query_models import TermMatch, ExistsMatch
 # in a list of dicts
 def keypaths(nested):
     ''' return a list of nested dict key paths
-        like: [u'_source', u'details', u'hostname']
+        like: [u'_source', u'details', u'program']
     '''
     for key, value in nested.iteritems():
         if isinstance(value, collections.Mapping):

--- a/alerts/promisc_kernel.py
+++ b/alerts/promisc_kernel.py
@@ -27,7 +27,7 @@ class PromiscKernel(AlertTask):
         ])
 
         self.filtersManual(search_query)
-        self.searchEventsAggregated('details.hostname', samplesLimit=10)
+        self.searchEventsAggregated('hostname', samplesLimit=10)
         self.walkAggregations(threshold=1)
 
     def onAggregation(self, aggreg):

--- a/alerts/session_opened_sensitive_user.py
+++ b/alerts/session_opened_sensitive_user.py
@@ -57,10 +57,10 @@ class SessionOpenedUser(AlertTask):
         tags = ['pam', 'syslog']
 
         uniquehosts = []
-        sorted_events = sorted(aggreg['events'], key=lambda x: x['_source']['details']['hostname'])
+        sorted_events = sorted(aggreg['events'], key=lambda x: x['_source']['hostname'])
         for e in sorted_events:
-            if e['_source']['details']['hostname'] not in uniquehosts:
-                uniquehosts.append(e['_source']['details']['hostname'])
+            if e['_source']['hostname'] not in uniquehosts:
+                uniquehosts.append(e['_source']['hostname'])
 
         summary = 'Session opened by a sensitive user outside of the expected window - sample hosts: {0} [total {1} hosts]'.format(' '.join(uniquehosts), aggreg['count'])
 

--- a/alerts/ssh_access_signreleng.py
+++ b/alerts/ssh_access_signreleng.py
@@ -25,7 +25,7 @@ class AlertAuthSignRelengSSH(AlertTask):
         search_query.add_must([
             TermMatch('tags', 'releng'),
             TermMatch('details.program', 'sshd'),
-            QueryStringMatch('details.hostname: /{}/'.format(self.config.hostfilter)),
+            QueryStringMatch('hostname: /{}/'.format(self.config.hostfilter)),
             PhraseMatch('summary', 'Accepted publickey for ')
         ])
 
@@ -53,9 +53,9 @@ class AlertAuthSignRelengSSH(AlertTask):
         targethost = 'unknown'
         sourceipaddress = 'unknown'
         x = event['_source']
+        if 'hostname' in x:
+            targethost = x['hostname']
         if 'details' in x:
-            if 'hostname' in x['details']:
-                targethost = x['details']['hostname']
             if 'sourceipaddress' in x['details']:
                 sourceipaddress = x['details']['sourceipaddress']
 

--- a/alerts/ssh_lateral.py
+++ b/alerts/ssh_lateral.py
@@ -85,7 +85,7 @@ class SshLateral(AlertTask):
         ])
 
         self.filtersManual(search_query)
-        self.searchEventsAggregated('details.hostname', samplesLimit=10)
+        self.searchEventsAggregated('hostname', samplesLimit=10)
         self.walkAggregations(threshold=1)
 
     # Returns true if the user, host, and source IP fall into an exception
@@ -107,7 +107,7 @@ class SshLateral(AlertTask):
         # hostmustmatch, and then negate matches using hostmustnotmatch
         if len(aggreg['events']) == 0:
             return None
-        srchost = aggreg['events'][0]['_source']['details']['hostname']
+        srchost = aggreg['events'][0]['_source']['hostname']
         srcmatch = False
         for x in self._config['hostmustmatch']:
             if re.match(x, srchost) != None:

--- a/alerts/unauth_ssh.py
+++ b/alerts/unauth_ssh.py
@@ -31,7 +31,7 @@ class AlertUnauthSSH(AlertTask):
         search_query.add_must([
             TermMatch('category', 'syslog'),
             TermMatch('details.program', 'sshd'),
-            QueryStringMatch('details.hostname: /{}/'.format(self.config.hostfilter)),
+            QueryStringMatch('hostname: /{}/'.format(self.config.hostfilter)),
             PhraseMatch('summary', 'Accepted publickey for {}'.format(self.config.user))
         ])
 
@@ -58,9 +58,9 @@ class AlertUnauthSSH(AlertTask):
         targethost = 'unknown'
         sourceipaddress = 'unknown'
         x = event['_source']
+        if 'hostname' in x:
+            targethost = x['hostname']
         if 'details' in x:
-            if 'hostname' in x['details']:
-                targethost = x['details']['hostname']
             if 'sourceipaddress' in x['details']:
                 sourceipaddress = x['details']['sourceipaddress']
 

--- a/mq/plugins/mozilla_location.py
+++ b/mq/plugins/mozilla_location.py
@@ -34,4 +34,15 @@ class message(object):
                         message['details']['sitetype'] = 'office'
                     else:
                         message['details']['sitetype'] = 'unknown'
+        elif 'hostname' in message.keys():
+            hostnamesplit = str.lower(message['hostname'].encode('ascii', 'ignore')).split('.')
+            if len(hostnamesplit) == 5:
+                if 'mozilla' == hostnamesplit[-2]:
+                    message['details']['site'] = hostnamesplit[-3]
+                    if message['details']['site'] in self.dc_code_list:
+                        message['details']['sitetype'] = 'datacenter'
+                    elif message['details']['site'] in self.offices_code_list:
+                        message['details']['sitetype'] = 'office'
+                    else:
+                        message['details']['sitetype'] = 'unknown'
         return (message, metadata)

--- a/mq/plugins/observium.py
+++ b/mq/plugins/observium.py
@@ -23,9 +23,9 @@ class message(object):
                     msg_unparsed = message['summary']
                     search = re.search(self.regex, msg_unparsed)
                     if search:
+                        message['hostname'] = search.group('source_host')
                         message['details']['alert_type'] = search.group('alert_type')
                         message['details']['entity_type'] = search.group('entity_type')
-                        message['details']['hostname'] = search.group('source_host')
                         message['details']['entity'] = search.group('entity')
                         message['details']['alert_message'] = search.group('alert_message')
                         # tag the message

--- a/mq/plugins/snmptt.py
+++ b/mq/plugins/snmptt.py
@@ -27,5 +27,10 @@ class message(object):
                         message['details']['trapseverity'] = search.group('trapseverity')
                         message['details']['trappayload'] = search.group('trappayload')
                         message['hostname'] = search.group('source_host')
+                        # tag the message
+                        if 'tags' in message.keys() and isinstance(message['tags'], list):
+                            message['tags'].append('alert')
+                        else:
+                            message['tags'] = ['alert']   
 
         return (message, metadata)

--- a/mq/plugins/snmptt.py
+++ b/mq/plugins/snmptt.py
@@ -25,8 +25,7 @@ class message(object):
                     if search:
                         message['details']['trapname'] = search.group('trapname')
                         message['details']['trapseverity'] = search.group('trapseverity')
-                        message['details']['sourcehostname'] = search.group('source_host')
                         message['details']['trappayload'] = search.group('trappayload')
-                        message['details']['hostname'] = search.group('source_host')
+                        message['hostname'] = search.group('source_host')
 
         return (message, metadata)

--- a/tests/alerts/test_bruteforce_ssh.py
+++ b/tests/alerts/test_bruteforce_ssh.py
@@ -18,9 +18,9 @@ class TestAlertBruteforceSsh(AlertTestSuite):
         "_type": "event",
         "_source": {
             "summary": 'login invalid ldap_count_entries failed by 1.2.3.4',
+            "hostname": "exhostname",
             "details": {
                 "program": "sshd",
-                "hostname": "exhostname",
                 "sourceipaddress": "1.2.3.4",
             }
         }

--- a/tests/alerts/test_promisc_kernel.py
+++ b/tests/alerts/test_promisc_kernel.py
@@ -16,7 +16,7 @@ class TestPromiscKernel(AlertTestSuite):
             "summary": "device eth0 entered promiscuous mode",
             "hostname": "logging.server.com",
             "details": {
-                "hostname": "random.hacked.server.yours",
+                "program": "kernel",
             }
         }
     }
@@ -25,7 +25,7 @@ class TestPromiscKernel(AlertTestSuite):
     default_alert = {
         "category": "promisc",
         "severity": "WARNING",
-        "summary": "Promiscuous mode enabled on random.hacked.server.yours [10]",
+        "summary": "Promiscuous mode enabled on logging.server.com [10]",
         "tags": ['promisc', 'kernel'],
     }
 
@@ -57,6 +57,16 @@ class TestPromiscKernel(AlertTestSuite):
     test_cases.append(
         NegativeAlertTestCase(
             description="Negative test case with bad eventName",
+            events=events,
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_source']['details']['program'] = "badprogram"
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with bad program name",
             events=events,
         )
     )

--- a/tests/alerts/test_promisc_kernel.py
+++ b/tests/alerts/test_promisc_kernel.py
@@ -63,16 +63,6 @@ class TestPromiscKernel(AlertTestSuite):
 
     events = AlertTestSuite.create_events(default_event, 10)
     for event in events:
-        event['_source']['details']['program'] = "badprogram"
-    test_cases.append(
-        NegativeAlertTestCase(
-            description="Negative test case with bad program name",
-            events=events,
-        )
-    )
-
-    events = AlertTestSuite.create_events(default_event, 10)
-    for event in events:
         event['_source']['summary'] = "Promisc: Interface eth0 set promiscuous off"
     test_cases.append(
         NegativeAlertTestCase(

--- a/tests/alerts/test_session_opened_sensitive_user.py
+++ b/tests/alerts/test_session_opened_sensitive_user.py
@@ -19,10 +19,10 @@ class TestSessionOpenedUser(AlertTestSuite):
         "_type": "event",
         "_source": {
             "category": "syslog",
+            "hostname": "exhostname",
             "summary": 'pam_unix(sshd:session): session opened for user user1 by (uid=0)',
             "details": {
                 "program": "sshd",
-                "hostname": "exhostname",
             }
         }
     }
@@ -84,7 +84,7 @@ class TestSessionOpenedUser(AlertTestSuite):
     randomhostsalert['summary'] = "Session opened by a sensitive user outside of the expected window - sample hosts:"
     for event in events:
         randomhostname = 'host' + str(events.index(event))
-        event['_source']['details']['hostname'] = randomhostname
+        event['_source']['hostname'] = randomhostname
         randomhostsalert['summary'] += ' {0}'.format(randomhostname)
     randomhostsalert['summary'] += " [total 10 hosts]"
     test_cases.append(

--- a/tests/alerts/test_ssh_access_signreleng.py
+++ b/tests/alerts/test_ssh_access_signreleng.py
@@ -14,10 +14,10 @@ class TestAlertSSHAccessSignReleng(AlertTestSuite):
         "_type": "event",
         "_source": {
             "tags": ["releng"],
+            "hostname": 'host1',
             "summary": 'Accepted publickey for ttesterson from 1.2.3.4 port 39190 ssh2',
             "details": {
                 "sourceipaddress": "1.2.3.4",
-                "hostname": 'host1',
                 "program": 'sshd'
             }
         }
@@ -107,7 +107,7 @@ class TestAlertSSHAccessSignReleng(AlertTestSuite):
     )
 
     event = AlertTestSuite.create_event(default_event)
-    event['_source']['details']['hostname'] = 'badhostname'
+    event['_source']['hostname'] = 'badhostname'
     test_cases.append(
         NegativeAlertTestCase(
             description="Negative test case with bad hostname",


### PR DESCRIPTION
details.hostname is a field added due to heka parsing. This is to normalize hostname data fields after decom of heka within our pipeline. The top level mandatory field will be the only field to contain the event source hostname for eventtask events that are parsed. Other hostname fields will be reviewed in a later phase in other data sources.

Many MQ Plugins add the hostname to the details.hostname field. There are also alerts which look for details.hostname to obtain the hostname for an alert. I propose that we add code to look for or validate the top level hostname field, and leave the details.hostname field in the plugin if applicable until we validate that absolutely nothing is using it. Once we can validate that nothing is coming in with details.hostname populated, we can remove that portion of the codefrom our plugins. All alerts that use the details.hostname field do have the top level hostname field and they match. So no need to keep the details.hostname field around in those particular scripts.

The only real modification where we look for both is in the mozilla_location plugin.
This would simply be an addition of an elif, or, and if statements looking for hostname in the top level in addition to the one looking for it in details.hostname. Any plugins that define details.hostname will be changed to just be hostname in the top level.
