### PR TITLE
Add connect proxy drops to non-std ports alert

### DIFF
--- a/alerts/proxy_drop_non_standard_port.conf
+++ b/alerts/proxy_drop_non_standard_port.conf
@@ -1,0 +1,2 @@
+[options]
+excludedports = 443,8443

--- a/alerts/proxy_drop_non_standard_port.py
+++ b/alerts/proxy_drop_non_standard_port.py
@@ -24,7 +24,7 @@ class AlertProxyDropNonStandardPort(AlertTask):
             TermMatch('details.tcpaction', 'CONNECT')
         ])
 
-        # Only notify on certain file extensions from config
+        # Only notify on certain ports from config
         filename_regex = "/.*:({0})/".format(
             self.config.excludedports.replace(',', '|'))
         search_query.add_must_not([

--- a/alerts/proxy_drop_non_standard_port.py
+++ b/alerts/proxy_drop_non_standard_port.py
@@ -12,6 +12,9 @@ from query_models import QueryStringMatch, SearchQuery, TermMatch
 
 class AlertProxyDropNonStandardPort(AlertTask):
     def main(self):
+        self.parse_config(
+            'proxy_drop_non_standard_port.conf', ['excludedports'])
+
         search_query = SearchQuery(minutes=20)
 
         search_query.add_must([
@@ -21,8 +24,11 @@ class AlertProxyDropNonStandardPort(AlertTask):
             TermMatch('details.tcpaction', 'CONNECT')
         ])
 
+        # Only notify on certain file extensions from config
+        filename_regex = "/.*:({0})/".format(
+            self.config.excludedports.replace(',', '|'))
         search_query.add_must_not([
-            QueryStringMatch('details.destination: /.*:443/')
+            QueryStringMatch('details.destination: {}'.format(filename_regex))
         ])
 
         self.filtersManual(search_query)

--- a/alerts/proxy_drop_non_standard_port.py
+++ b/alerts/proxy_drop_non_standard_port.py
@@ -25,10 +25,10 @@ class AlertProxyDropNonStandardPort(AlertTask):
         ])
 
         # Only notify on certain ports from config
-        filename_regex = "/.*:({0})/".format(
+        port_regex = "/.*:({0})/".format(
             self.config.excludedports.replace(',', '|'))
         search_query.add_must_not([
-            QueryStringMatch('details.destination: {}'.format(filename_regex))
+            QueryStringMatch('details.destination: {}'.format(port_regex))
         ])
 
         self.filtersManual(search_query)

--- a/alerts/proxy_drop_non_standard_port.py
+++ b/alerts/proxy_drop_non_standard_port.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+
+
+from lib.alerttask import AlertTask
+from query_models import SearchQuery, TermMatch, ExistsMatch
+
+
+class AlertProxyDropNonStandardPort(AlertTask):
+    def main(self):
+        search_query = SearchQuery(minutes=5)
+
+        search_query.add_must([
+            TermMatch('category', 'squid'),
+            TermMatch('details.proxyaction', 'TCP_DENIED/-'),
+            TermMatch('details.tcpaction', 'CONNECT'),
+        ])
+
+        search_query.add_must_not([
+            PhraseMatch('details.destination', ':443')
+        ])
+
+        self.filtersManual(search_query)
+
+        # Search aggregations on field 'ip', keep X samples of events at most
+        self.searchEventsAggregated('details.sourceipaddress', samplesLimit=10)
+        # alert when >= X matching events in an aggregation
+        self.walkAggregations(threshold=1)
+
+    # Set alert properties
+    def onAggregation(self, aggreg):
+        # aggreg['count']: number of items in the aggregation, ex: number of failed login attempts
+        # aggreg['value']: value of the aggregation field, ex: toto@example.com
+        # aggreg['events']: list of events in the aggregation
+        category = 'squid'
+        tags = ['squid', 'proxy']
+        severity = 'WARNING'
+
+        destinations = []
+
+        for event in aggreg['allevents']:
+           destinations.append(event['_source']['details.destination'])
+
+        summary = ('Suspicious proxy activity from {0} attempting to reach non-std services: {1}'.format(aggreg['value'], join(", ", destinations))
+
+        return self.createAlertDict(summary, category, tags, aggreg['events'], severity)

--- a/tests/alerts/test_proxy_drop_non_standard_port.py
+++ b/tests/alerts/test_proxy_drop_non_standard_port.py
@@ -1,0 +1,80 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+from positive_alert_test_case import PositiveAlertTestCase
+from negative_alert_test_case import NegativeAlertTestCase
+
+from alert_test_suite import AlertTestSuite
+
+
+class TestAlertSSHPasswordAuthViolation(AlertTestSuite):
+    alert_filename = "proxy_drop_non_standard_port"
+
+    # This event is the default positive event that will cause the
+    # alert to trigger
+    default_event = {
+        "_type": "event",
+        "_source": {
+            "category": "squid",
+            "tags": ["squid"],
+            "details": {
+                "details.sourceipaddress": "1.2.3.4",
+                "details.destination": "evil.com:6667",
+                "details.proxyaction": "TCP_DENIED/-",
+                "details.tcpaction": "CONNECT",
+            }
+        }
+    }
+
+    # This alert is the expected result from running this task
+    default_alert = {
+        "category": "squid",
+        "tags": ['squid', 'proxy'],
+        "severity": "WARNING",
+        "summary": 'Suspicious proxy activity from 1.2.3.4 attempting to reach non-std services: evil.com:6667',
+    }
+
+    test_cases = []
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test with default events and default alert expected",
+            events=AlertTestSuite.create_events(default_event, 1),
+            expected_alert=default_alert
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_source']['category'] = 'bad'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with events with incorrect category",
+            events=events,
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_source']['tags'] = 'bad tag example'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with events with incorrect tags",
+            events=events,
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({
+                                                                                         'minutes': 241})
+        event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({
+                                                                                              'minutes': 241})
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with old timestamp",
+            events=events,
+        )
+    )


### PR DESCRIPTION
This aims to capture occurances where an attacker is attempting (and failing) to egress via the proxy and making it an alert that IR responders can act on.