### PR TITLE
Fixing details.dhost to be hostname

### DIFF
--- a/mq/plugins/auditdFixup.py
+++ b/mq/plugins/auditdFixup.py
@@ -102,7 +102,7 @@ class message(object):
                 del message['details']['gid']
 
        # fix details.dhost to be hostname
-       if 'details' in message.key() and isinstance(message['details'], dict):
+       if 'details' in message.keys() and isinstance(message['details'], dict):
            if 'dhost' in message['details'].keys():
                # details.dhost is the host that the auditd event is happening on.
                message['hostname'] = message['details']['dhost']

--- a/mq/plugins/auditdFixup.py
+++ b/mq/plugins/auditdFixup.py
@@ -101,6 +101,13 @@ class message(object):
                 message['details']['gidstring'] = message['details']['gid']
                 del message['details']['gid']
 
+       # fix details.dhost to be hostname
+       if 'details' in message.key() and isinstance(message['details'], dict):
+           if 'dhost' in message['details'].keys():
+               # details.dhost is the host that the auditd event is happening on.
+               message['hostname'] = message['details']['dhost']
+               del message['details']['dhost']
+
         # add category
         if 'category' not in message.keys():
             message['category'] = 'auditd'


### PR DESCRIPTION
in these events, hostname is normally populated as UNKNOWN, while details.dhost is populated with the hostname. This PR corrects this by moving details.dhost into the hostname field.