### PR TITLE
If cluster_client_ip is present there seems to be no reason to use th…

### DIFF
--- a/mq/plugins/ipFixup.py
+++ b/mq/plugins/ipFixup.py
@@ -128,5 +128,9 @@ class message(object):
 
             if 'cluster_client_ip' in message['details'].keys():
                 ipText = message['details']['cluster_client_ip']
+                if isIPv4(ipText):
+                    message['details']['sourceipaddress'] = ipText
+                if isIPv6(ipText):
+                    message['details']['sourceipv6address'] = ipText
 
         return (message, metadata)

--- a/mq/plugins/ipFixup.py
+++ b/mq/plugins/ipFixup.py
@@ -128,7 +128,5 @@ class message(object):
 
             if 'cluster_client_ip' in message['details'].keys():
                 ipText = message['details']['cluster_client_ip']
-                if isIPv4(ipText) and 'sourceipaddress' not in message['details'].keys():
-                    message['details']['sourceipaddress'] = ipText
 
         return (message, metadata)


### PR DESCRIPTION
…e sourceipaddress. The cluster_client_ip should overwrite as the 'true' client's IP. This is to enable anomaly detection, like Geo, on traffic going through load balancers.