### PR TITLE
docker nginx proxy pass fix

### DIFF
--- a/docker/compose/nginx/files/nginx.conf
+++ b/docker/compose/nginx/files/nginx.conf
@@ -9,6 +9,7 @@ events {
 http {
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
+  resolver 127.0.0.11;
 
   log_format main
           '$remote_addr - $remote_user [$time_local] '

--- a/docker/compose/nginx/files/nginx.conf
+++ b/docker/compose/nginx/files/nginx.conf
@@ -51,8 +51,10 @@ http {
     listen              *:80;
     access_log          off;
 
+    set $meteor_proxy_pass_url http://meteor:3000;
+
     location /{
-      proxy_pass http://meteor:3000;
+      proxy_pass $meteor_proxy_pass_url;
       proxy_read_timeout 90;
     }
   }
@@ -60,8 +62,11 @@ http {
   ## loginput ##
   server{
     listen              *:8080;
+
+    set $loginput_proxy_pass_url http://loginput:8080;
+
     location /{
-      proxy_pass http://loginput:8080;
+      proxy_pass $loginput_proxy_pass_url;
       proxy_read_timeout 90;
     }
   }
@@ -69,8 +74,11 @@ http {
   ## restapi ##
   server{
     listen              *:8081;
+
+    set $rest_proxy_pass_url http://rest:8081;
+
     location /{
-      proxy_pass http://rest:8081;
+      proxy_pass $rest_proxy_pass_url;
       proxy_read_timeout 90;
     }
   }
@@ -80,9 +88,11 @@ http {
     listen              *:9090;
     access_log          off;
 
+    set $kibana_proxy_pass_url http://kibana:5601;
+
     location /{
       proxy_http_version   1.1;
-      proxy_pass           http://kibana:5601;
+      proxy_pass           $kibana_proxy_pass_url;
       proxy_read_timeout   90;
       proxy_set_header     Upgrade             $http_upgrade;
       proxy_set_header     Connection 'upgrade';

--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -9,6 +9,7 @@ events {
 http {
 	include /etc/nginx/mime.types;
 	default_type application/octet-stream;
+	resolver 127.0.0.11;
 
 	log_format main
 	        '$remote_addr - $remote_user [$time_local] '

--- a/docker/conf/nginx.conf
+++ b/docker/conf/nginx.conf
@@ -48,8 +48,11 @@ http {
   server{
     listen              *:80;
     access_log          off;
+
+		set $meteor_proxy_pass_url http://127.0.0.1:3000;
+
     location /{
-      proxy_pass http://127.0.0.1:3000;
+      proxy_pass $meteor_proxy_pass_url;
       proxy_read_timeout 90;
     }
   }
@@ -60,9 +63,11 @@ http {
     server_name         localhost;
     access_log          off;
 
+		set $kibana_proxy_pass_url http://127.0.0.1:5601;
+
     location /{
       proxy_http_version   1.1;
-      proxy_pass           http://127.0.0.1:5601;
+      proxy_pass           $kibana_proxy_pass_url;
       proxy_read_timeout   90;
       proxy_set_header     Upgrade             $http_upgrade;
       proxy_set_header     Connection 'upgrade';


### PR DESCRIPTION
nginx, by default, only resolves a proxy_pass one time unless it contains a variable. That means that if meteor, loginput, restapi or kibana are restarted that nginx would have to be restarted as well in order to get the new internal container ip address of the upstream.  Moving all of the proxy_pass upstreams into a variable forces nginx to resolve them.