### PR TITLE
Fix makefile s3 upload

### DIFF
--- a/cloudy_mozdef/Makefile
+++ b/cloudy_mozdef/Makefile
@@ -46,4 +46,4 @@ stack-status: ## Output current CloudFormation stack status
 
 .PHONY: upload-templates
 upload-templates:
-	$(DOCKER_BASH_RUN) "aws s3 sync /opt/mozdef/cloudformation/ $(S3_BUCKET_URI) --acl public-read"
+	aws s3 sync cloudformation/ $(S3_BUCKET_URI) --acl public-read


### PR DESCRIPTION
Revert f0a5db246ee9f9115e81509672176d7efde06867 to get back awscli credential resolution logic which searches through environment variables, and files
