### PR TITLE
Add CloudTrail and SQS event consumption support

### DIFF
--- a/cloudy_mozdef/cloudformation/base-iam.yml
+++ b/cloudy_mozdef/cloudformation/base-iam.yml
@@ -1,28 +1,123 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Description: "Creates the MozDef base instance profile and delivery server IAM role"
+Parameters:
+  CloudTrailS3BucketName:
+    Type: String
+    Description: "The name of the S3 Bucket containing the CloudTrail logs"
+  CloudTrailSQSQueueArn:
+    Type: String
+    Description: "The ARN of the SQS queue that receives SNS notifications each time a new CloudTrail log is written to S3"
+  CloudTrailS3BucketIAMRoleArn:
+    Type: String
+    Description: "The ARN of an IAM Role that MozDef should assume in order to read from the S3 Bucket containing the CloudTrail logs"
+    Default: ""
+  MozDefSQSQueueArn:
+    Type: String
+    Description: "The ARN of the SQS queue that receives events destined for MozDef"
+Conditions:
+  IAMRoleSet:
+    !Not [!Equals [!Ref CloudTrailS3BucketIAMRoleArn, ""]]
 Resources:
-  WebRole:
+  MozDefCloudTrailPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Metadata:
+      AllowReadCloudTrailLogsListBucket:
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_cloudtrail.py#L341
+      AllowReadCloudTrailLogsGetObject:
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_cloudtrail.py#L343
+      AllowReadDeleteFromCloudTrailSQSQueue:
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/lib/sqs.py#L11
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_cloudtrail.py#L317
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_cloudtrail.py#L348
+    Properties:
+      Description: Policy to access CloudTrail logs
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowReadCloudTrailLogsListBucket
+            Effect: Allow
+            Action: s3:ListBucket
+            Resource: '*'
+          - Sid: AllowReadCloudTrailLogsGetObject
+            Effect: Allow
+            Action: s3:GetObject*
+            Resource: !Join ["", ["arn:aws:s3:::", !Ref CloudTrailS3BucketName, "/AWSLogs/*"]]
+          - Sid: AllowReadDeleteFromCloudTrailSQSQueue
+            Effect: Allow
+            Action:
+              - sqs:GetQueueUrl
+              - sqs:ReceiveMessage
+              - sqs:DeleteMessage
+            Resource: !Ref CloudTrailSQSQueueArn
+  MozDefCloudTrailRoleAssumptionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Metadata:
+      AllowGetSessionToken:
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_cloudtrail.py#L54
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_cloudtrail.py#L72
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_cloudtrail.py#L67
+      AllowAssumeRole:
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_cloudtrail.py#L98
+    Condition: IAMRoleSet
+    Properties:
+      Description: Policy to access CloudTrail logs
+      Roles:
+        - !Ref MozDefIAMRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowGetSessionToken
+            Effect: Allow
+            Action: sts:GetSessionToken
+            Resource: "*"
+          - Sid: AllowAssumeRole
+            Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !Ref CloudTrailS3BucketIAMRoleArn
+  MozdefSQSPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Metadata:
+      AllowReadDeleteFromSQSQueues:
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/lib/sqs.py#L11
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_sqs.py#L176
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_sqs.py#L192
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_sqs.py#L199
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_sqs.py#L226
+        - https://github.com/mozilla/MozDef/blob/4b43aa57c375ea1c97118abea49f870a396a9862/mq/esworker_sqs.py#L231
+    Properties:
+      Description: Policy to access mozdef SQS queues
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowReadDeleteFromSQSQueues
+            Effect: Allow
+            Action:
+              - sqs:GetQueueUrl
+              - sqs:ReceiveMessage
+              - sqs:DeleteMessage
+            Resource: !Ref MozDefSQSQueueArn
+  MozDefIAMRole:
     Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
-          -
-            Effect: "Allow"
+          - Effect: "Allow"
             Principal:
-              Service:
-                - "ec2.amazonaws.com"
-            Action:
-              - "sts:AssumeRole"
-  # Attach the instance profile here for cleanlieness.
+              Service: "ec2.amazonaws.com"
+            Action: "sts:AssumeRole"
+      ManagedPolicyArns:
+        - !Ref MozDefCloudTrailPolicy
+        # MozDefCloudTrailRoleAssumptionPolicy is not listed here because it's
+        # optional and attached to this role within the policy itself
+        - !Ref MozdefSQSPolicy
   InstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
       Roles:
-        -
-          Ref: WebRole
+        - Ref: MozDefIAMRole
 Outputs:
   InstanceProfileArn:
-    Description: The arn of the instanceprofile.
+    Description: The arn of the Instance Profile
     Value: !GetAtt InstanceProfile.Arn

--- a/cloudy_mozdef/cloudformation/mozdef-cloudtrail.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-cloudtrail.yml
@@ -1,0 +1,97 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Global CloudTrail, S3 Bucket and SNS Topic
+Resources:
+  MozDefCloudTrail:
+    Type: AWS::CloudTrail::Trail
+    DependsOn:
+      - MozDefCloudTrailBucketPolicy
+      - MozDefCloudTrailSNSTopicPolicy
+      - MozDefCloudTrailSNSSQSSubscription
+      - MozDefCloudTrailSQSQueuePolicy
+    Properties:
+      S3BucketName: !Ref MozDefCloudTrailBucket
+      SnsTopicName: !GetAtt MozDefCloudTrailSNSTopic.TopicName
+      IsLogging: true
+      IncludeGlobalServiceEvents: true
+      IsMultiRegionTrail: true
+  MozDefCloudTrailBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+  MozDefCloudTrailBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref MozDefCloudTrailBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AWSCloudTrailAclCheck
+            Effect: Allow
+            Principal:
+              Service: "cloudtrail.amazonaws.com"
+            Action: "s3:GetBucketAcl"
+            Resource: !GetAtt MozDefCloudTrailBucket.Arn
+          - Sid: AWSCloudTrailWrite
+            Effect: Allow
+            Principal:
+              Service: "cloudtrail.amazonaws.com"
+            Action: "s3:PutObject"
+            Resource: !Join ["/", [ !GetAtt MozDefCloudTrailBucket.Arn, "AWSLogs", !Ref "AWS::AccountId", "*"]]
+            Condition:
+              StringEquals:
+                "s3:x-amz-acl": "bucket-owner-full-control"
+  MozDefCloudTrailSNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: AllowCloudTrailToPublishToSNS
+          Effect: Allow
+          Principal:
+            Service: "cloudtrail.amazonaws.com"
+          Action: "sns:Publish"
+          Resource: !Ref MozDefCloudTrailSNSTopic
+      Topics:
+      - !Ref MozDefCloudTrailSNSTopic
+  MozDefCloudTrailSNSTopic:
+    Type: AWS::SNS::Topic
+  MozDefCloudTrailSQSQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Sid: AllowSNSToSendToSQS
+          Effect: Allow
+          Principal: "*"
+          Action: "sqs:SendMessage"
+          Resource: !GetAtt MozDefCloudTrailSQSQueue.Arn
+          Condition:
+            ArnEquals:
+              "aws:SourceArn": !Ref MozDefCloudTrailSNSTopic
+      Queues:
+        - !Ref MozDefCloudTrailSQSQueue
+  MozDefCloudTrailSQSQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      Tags:
+      - Key: application
+        Value: mozdef
+      - Key: stack
+        Value: !Ref "AWS::StackName"
+  MozDefCloudTrailSNSSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !GetAtt MozDefCloudTrailSQSQueue.Arn
+      Protocol: sqs
+      TopicArn: !Ref MozDefCloudTrailSNSTopic
+Outputs:
+  CloudTrailS3BucketName:
+    Description: "Name of the S3 Bucket containing CloudTrail logs"
+    Value: !Ref MozDefCloudTrailBucket
+  CloudTrailSQSQueueArn:
+    Description: "ARN of the SQS Queue that will receive notifications of new CloudTrail logs in S3"
+    Value: !GetAtt MozDefCloudTrailSQSQueue.Arn
+  CloudTrailSQSQueueName:
+    Description: "Name of the SQS Queue that will receive notifications of new CloudTrail logs in S3"
+    Value: !GetAtt MozDefCloudTrailSQSQueue.QueueName

--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -67,6 +67,11 @@ Resources:
   MozDefIAMRoleAndInstanceProfile:
     Type: AWS::CloudFormation::Stack
     Properties:
+      Parameters:
+        CloudTrailS3BucketName: !GetAtt MozDefCloudTrail.Outputs.CloudTrailS3BucketName
+        CloudTrailSQSQueueArn: !GetAtt MozDefCloudTrail.Outputs.CloudTrailSQSQueueArn
+        MozDefSQSQueueArn: !GetAtt MozDefSQS.Outputs.SQSQueueArn
+        # CloudTrailS3BucketIAMRoleArn we leave empty as we will consume CloudTrail logs from our own account
       Tags:
         - Key: application
           Value: mozdef
@@ -127,6 +132,24 @@ Resources:
         - Key: stack
           Value: !Ref "AWS::StackName"
       TemplateURL: !Join [ "", [ !Ref S3TemplateLocation, "mozdef-efs.yml" ] ]
+  MozDefSQS:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+      - Key: application
+        Value: mozdef
+      - Key: stack
+        Value: !Ref "AWS::StackName"
+      TemplateURL: !Join [ "", [ !Ref S3TemplateLocation, "mozdef-sqs.yml" ] ]
+  MozDefCloudTrail:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Tags:
+      - Key: application
+        Value: mozdef
+      - Key: stack
+        Value: !Ref "AWS::StackName"
+      TemplateURL: !Join [ "", [ !Ref S3TemplateLocation, "mozdef-cloudtrail.yml" ] ]
   CloudFormationLambdaIAMRole:
     Type: AWS::IAM::Role
     Properties:

--- a/cloudy_mozdef/cloudformation/mozdef-sqs.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-sqs.yml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: SQS Queue that MozDef consumes events from
+Resources:
+  MozDefSQSQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      Tags:
+      - Key: application
+        Value: mozdef
+      - Key: stack
+        Value: !Ref "AWS::StackName"
+Outputs:
+  SQSQueueArn:
+    Description: "ARN of the SQS Queue that MozDef will consume events from"
+    Value: !GetAtt MozDefSQSQueue.Arn
+  SQSQueueName:
+    Description: "Name of the SQS Queue that MozDef will consume events from"
+    Value: !GetAtt MozDefSQSQueue.QueueName


### PR DESCRIPTION
Create an S3 bucket to store CloudTrail logs
Create an SNS Topic to receive notifications of new CloudTrail logs
Create an SQS Topic for inbound event consumption
Create policies to wire everything up
Create CloudTrail
Update the IAM policy to allow MozDef to use these facilities