### PR TITLE
Remove details.apiversion to mq plugin

### DIFF
--- a/mq/plugins/cloudtrail.py
+++ b/mq/plugins/cloudtrail.py
@@ -42,8 +42,7 @@ class message(object):
             'details.requestparameters.disableApiTermination',
             'details.responseelements.findings.service.additionalInfo.unusual',
             'details.responseelements.distribution.distributionConfig.callerReference',
-            'details.requestparameters.logStreamName',
-            'details.apiversion'
+            'details.requestparameters.logStreamName'
         ]
 
     def convert_key_raw_str(self, needle, haystack):


### PR DESCRIPTION
So unfortunately this didn't work as we expected, because we already specify details.apiversion as a keyword in the default mapping -> https://github.com/mozilla/MozDef/blob/master/cron/defaultMappingTemplate.json#L114 

We gotta revisit this to see how better to solve it.