### PR TITLE
Enable dmake to use all AWS environment variables

### DIFF
--- a/cloudy_mozdef/dmake
+++ b/cloudy_mozdef/dmake
@@ -39,9 +39,7 @@ fi
 
 dmake_env_file="`mktemp`"
 trap "{ rm -f \"$dmake_env_file\"; }" EXIT
-env | egrep "^AWS" > "$dmake_env_file"
-
-cat $dmake_env_file
+env | egrep "^AWS|OIDC_CLIENT_SECRET" > "$dmake_env_file"
 
 exec docker run --rm --name ${CONTAINER_NAME} \
   -u $(id -u) \
@@ -49,5 +47,4 @@ exec docker run --rm --name ${CONTAINER_NAME} \
   ${config_file_mount} \
   -v $(pwd):${DOCKER_PROJECT_DIR} \
   --env-file "$dmake_env_file" \
-  -e "OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET}" \
   ${HUB}/${IMG_NAME}:latest make $@

--- a/cloudy_mozdef/dmake
+++ b/cloudy_mozdef/dmake
@@ -29,13 +29,25 @@ function check_img() {
 
 check_img || exit 127
 
+if [ -n "$AWS_CONFIG_FILE" ]; then
+  config_file_mount="-v ${AWS_CONFIG_FILE}:${AWS_CONFIG_FILE}"
+fi
+
+if [ -n "$AWS_SHARED_CREDENTIALS_FILE" ]; then
+  config_file_mount="${config_file_mount} -v ${AWS_SHARED_CREDENTIALS_FILE}:${AWS_SHARED_CREDENTIALS_FILE}"
+fi
+
+dmake_env_file="`mktemp`"
+trap "{ rm -f \"$dmake_env_file\"; }" EXIT
+env | egrep "^AWS" > "$dmake_env_file"
+
+cat $dmake_env_file
+
 exec docker run --rm --name ${CONTAINER_NAME} \
   -u $(id -u) \
   -v ${AWS_CREDS_DIR}:/root/.aws \
+  ${config_file_mount} \
   -v $(pwd):${DOCKER_PROJECT_DIR} \
-  -e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
-  -e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
-  -e "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" \
-  -e "AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}" \
-  -e "OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET}"
+  --env-file "$dmake_env_file" \
+  -e "OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET}" \
   ${HUB}/${IMG_NAME}:latest make $@

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -17,6 +17,8 @@ RUN echo -n "PS1=\"[deploy-shell][\u@\h \W]\$ \"" >> /root/.bashrc
 
 # Setup a home for deployment
 RUN mkdir -p /opt/mozdef
+RUN mkdir -p /.aws/cli/cache
+RUN chown --recursive 1000:1000 /.aws/cli/cache
 
 # Force this as the entrypoint
 WORKDIR /opt/mozdef


### PR DESCRIPTION
In #916 there was a missing `\` character [here](https://github.com/mozilla/MozDef/pull/916#pullrequestreview-170814992).

This PR fixes that and tries to accommodate all AWS environment variables.

I've tried testing this and it looks correct. When I bash into the container
* the environment variables are present
* the mounted files are mounted in the locations that the environment variables point to