### PR TITLE
let accounts module handle the stamped token

### DIFF
--- a/meteor/server/mozdef.js
+++ b/meteor/server/mozdef.js
@@ -184,12 +184,11 @@ function registerLoginViaHeader() {
             });
         }
 
-        //generate login tokens
-        var stampedToken = Accounts._generateStampedLoginToken();
-        // return ala: https://github.com/meteor/meteor/blob/devel/packages/accounts-base/accounts_server.js#L340
+        // per https://github.com/meteor/meteor/blob/devel/packages/accounts-base/accounts_server.js#L263
+        // generating and storing the stamped login token is optional
+        // so we just return the userId and let the accounts module do it's thing
         return {
-            userId: userId,
-            stampedLoginToken: stampedToken
+            userId: userId
         }
     });
 }


### PR DESCRIPTION
Previously we generated the token, returned it but didn't store it in the profile which didn't allow the accounts module to validate it. This removes us generating the token since the accounts module is going to do it anyway (and store it). 