### PR TITLE
Fix typo in overview

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -2,7 +2,7 @@ Overview
 ========
 What?
 -----
-Easiest to describe The Mozilla Defense Platform (MozDef) as a set of micro-services you can use as an open source Security Informaition and Event Management (SIEM) overlay on top of Elasticsearch.
+It's easiest to describe The Mozilla Defense Platform (MozDef) as a set of micro-services you can use as an open source Security Information and Event Management (SIEM) overlay on top of Elasticsearch.
 
 Why?
 ----


### PR DESCRIPTION
I noticed a typo in the overview while reading about the project.  Trivial change, even for documentation.