### PR TITLE
Logincounts fix

### DIFF
--- a/docker/compose/docker-compose-rest.yml
+++ b/docker/compose/docker-compose-rest.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.0'
+version: '3.7'
 services:
   rest:
     build:

--- a/docker/compose/docker-compose-sampledata.yml
+++ b/docker/compose/docker-compose-sampledata.yml
@@ -1,0 +1,18 @@
+---
+version: '3.7'
+services:
+  sampledata:
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_sampledata/Dockerfile
+    restart: always
+    command: bash -c 'source /opt/mozdef/envs/python/bin/activate && /opt/mozdef/envs/mozdef/examples/demo/sampleevents.sh'
+    links:
+      - elasticsearch
+    depends_on:
+      - loginput
+      - elasticsearch
+      - mongodb
+      - bootstrap
+    networks:
+      - default

--- a/examples/demo/sampleevents/events-logins-failure.json
+++ b/examples/demo/sampleevents/events-logins-failure.json
@@ -23,7 +23,7 @@
     "timestamp": "2014-08-05T20:38:39+00:00",
     "summary": "LDAP_INVALID_CREDENTIALS bob@example.com,o=com,dc=example srcIP=10.20.70.200",
     "details": {
-      "dn": "bob@example.com,o=com,dc=example",    
+      "dn": "bob@example.com,o=com,dc=example",
       "success": false,
       "sourceipv4address": "10.20.70.200",
       "result": "LDAP_INVALID_CREDENTIALS",
@@ -62,5 +62,54 @@
       "srcip": "10.20.0.200",
       "sourceipaddress": "10.20.0.200"
     }
+},
+{
+  "tags": [
+    "auth0",
+    "example"
+  ],
+  "summary": "Failed login for john@example.com",
+  "details": {
+    "username": "john@example.com",
+    "type": "Failed Login",
+    "success": false
+  }
+}
+,
+{
+  "tags": [
+    "auth0",
+    "example"
+  ],
+  "summary": "Failed login for bob@example.com",
+  "details": {
+    "username": "bob@example.com",
+    "type": "Failed Login",
+    "success": false
+  }
+},
+{
+  "tags": [
+    "auth0",
+    "example"
+  ],
+  "summary": "Failed login for mary@example.com",
+  "details": {
+    "username": "mary@example.com",
+    "type": "Failed Login",
+    "success": false
+  }
+},
+{
+  "tags": [
+    "auth0",
+    "example"
+  ],
+  "summary": "Failed login for sue@example.com",
+  "details": {
+    "username": "sue@example.com",
+    "type": "Failed Login",
+    "success": false
+  }
 }
 ]

--- a/examples/demo/sampleevents/events-logins-success.json
+++ b/examples/demo/sampleevents/events-logins-success.json
@@ -40,7 +40,7 @@
       "result": "LDAP_SUCCESS",
       "success": true
     }
-  },  
+  },
   {
     "tags": [
       "ldap",
@@ -52,6 +52,54 @@
       "source": "Apr 17 00:05:02 ldap slapd[15932]: conn=25123333 fd=93 ACCEPT from IP=10.0.0.209:8325 (IP=0.0.0.0:389)\nApr 17 00:05:02 ldap slapd[15932]: conn=25123333 op=0 BIND dn=\"uid=bind-openvpn,ou=logins,dc=example\" method=128\nApr 17 00:05:02 ldap slapd[15932]: conn=25123333 op=0 BIND dn=\"uid=vpn,ou=logins,dc=example\" mech=SIMPLE ssf=0\nApr 17 00:05:02 ldap slapd[15932]: conn=25123333 op=0 RESULT tag=97 err=0 text=\nApr 17 00:05:02 ldap slapd[15932]: conn=25123333 op=1 BIND anonymous mech=implicit ssf=0\nApr 17 00:05:02 ldap slapd[15932]: conn=25123333 op=1 BIND dn=\"mail=sue@example.com,o=com,dc=example\" method=128\nApr 17 00:05:02 ldap slapd[15932]: conn=25123333 op=1 BIND dn=\"mail=sue@example.com,o=com,dc=example\" mech=SIMPLE ssf=0\nApr 17 00:05:02 ldap slapd[15932]: conn=25123333 op=1 RESULT tag=97 err=0 text=\n",
       "srcip": "10.0.0.209",
       "result": "LDAP_SUCCESS",
+      "success": true
+    }
+  },
+  {
+    "tags": [
+      "auth0",
+      "example"
+    ],
+    "summary": "Success login for john@example.com",
+    "details": {
+      "username": "john@example.com",
+      "type": "Success Login",
+      "success": true
+    }
+  },
+  {
+    "tags": [
+      "auth0",
+      "example"
+    ],
+    "summary": "Success login for bob@example.com",
+    "details": {
+      "username": "bob@example.com",
+      "type": "Success Login",
+      "success": true
+    }
+  },
+  {
+    "tags": [
+      "auth0",
+      "example"
+    ],
+    "summary": "Success login for mary@example.com",
+    "details": {
+      "username": "mary@example.com",
+      "type": "Success Login",
+      "success": true
+    }
+  },
+  {
+    "tags": [
+      "auth0",
+      "example"
+    ],
+    "summary": "Success login for sue@example.com",
+    "details": {
+      "username": "sue@example.com",
+      "type": "Success Login",
       "success": true
     }
   }

--- a/meteor/client/logincounts.js
+++ b/meteor/client/logincounts.js
@@ -73,6 +73,7 @@ if (Meteor.isClient) {
                     //debugLog(err,result);
                     logincountsResult.status='error';
                     logincountsResult.error=err;
+                    container.style.cursor='auto';
                }
            });
 

--- a/meteor/client/logincounts.js
+++ b/meteor/client/logincounts.js
@@ -9,7 +9,9 @@ import d3 from 'd3';
 if (Meteor.isClient) {
     var logincountsResult = new Object;
 
-    //d3 code to animate login counts
+    // d3 code to animate login counts
+    // grouping by ratio of success
+    // to failures
     Template.logincounts.rendered = function () {
         container=document.getElementById('logins-wrapper')
         container.style.cursor='wait'
@@ -43,7 +45,6 @@ if (Meteor.isClient) {
         var node = svg.selectAll(".node"),
             link = svg.selectAll(".link");
 
-        //.domain([0, d3.max(force.nodes(), function(d) { return d.count; })])
         var r = d3.scale.sqrt()
             .range([0, maxRadius]);
 
@@ -60,7 +61,7 @@ if (Meteor.isClient) {
                     container.style.cursor='auto';
                     r.domain([0, d3.max(jsondata, function(d) { return d.success+ d.failures; })])
                     jsondata.forEach(function(d){
-                        d.id=d.dn;
+                        d.id=d.username;
                         d.count=(d.success +d.failures)
                         d.k = fraction(d.success, d.failures);
                         d.r = r(d.count);
@@ -84,7 +85,6 @@ if (Meteor.isClient) {
                 .append("a")
                 .attr("class", function(d) { return "node " + d.id; })
                 .attr("class", "node")
-                //.attr("r", function(d) {return Math.min(Math.max(d.failures,d.success)/20,20)})
                 .call(force.drag);
 
             // delineate between success/failures:
@@ -92,7 +92,7 @@ if (Meteor.isClient) {
                 .attr("class", "g-success");
 
             successEnter.append("clipPath")
-                .attr("id", function(d) { return "g-clip-success-" + d.dn; })
+                .attr("id", function(d) { return "g-clip-success-" + d.username; })
                 .append("rect");
 
             successEnter.append("circle")
@@ -103,7 +103,7 @@ if (Meteor.isClient) {
                 .attr("class", "g-failures");
 
             failureEnter.append("clipPath")
-                .attr("id", function(d) { return "g-clip-failure-" + d.dn; })
+                .attr("id", function(d) { return "g-clip-failure-" + d.username; })
                 .append("rect");
 
             failureEnter.append("circle")
@@ -112,7 +112,6 @@ if (Meteor.isClient) {
 
             node.append("line")
                 .attr("class", "g-split")
-                //.data(force.nodes())
                 .attr("x1", function(d) { return -d.cr + 2 * d.r * d.k; })
                 .attr("y1", function(d) {
                     return -Math.sqrt(d.cr * d.cr - Math.pow(-d.cr + 2 * d.cr * d.k, 2));
@@ -126,13 +125,13 @@ if (Meteor.isClient) {
                 .attr("x", 1)
                 .attr("y", ".3em")
                 .attr("class","textlabel")
-                .text(function(d) { return d.dn; });
+                .text(function(d) { return d.username; });
 
-            //make a mouse over for the success/failure counts
+            // make a mouse over for the success/failure counts
             node.append("title")
-              .text(function(d) { return d.dn + ": " + d.success + " / " + d.failures });
+              .text(function(d) { return d.username + ": " + d.success + " / " + d.failures });
 
-            //size circle clips
+            // size circle clips
             node.selectAll("rect")
               .attr("y", function(d) { return -d.r - clipPadding; })
               .attr("height", function(d) { return 2 * d.r + 2 * clipPadding; });
@@ -143,7 +142,7 @@ if (Meteor.isClient) {
               .attr("width", function(d) { return 2 * d.r * d.k + clipPadding; });
 
               node.select(".g-success circle")
-                .attr("clip-path", function(d) { return d.k < 1 ? "url(#g-clip-success-" + d.dn + ")" : null; });
+                .attr("clip-path", function(d) { return d.k < 1 ? "url(#g-clip-success-" + d.username + ")" : null; });
 
               node.select(".g-failures rect")
                 .style("display", function(d) { return d.k < 1 ? null : "none" })
@@ -151,7 +150,7 @@ if (Meteor.isClient) {
                 .attr("width", function(d) { return 2 * d.cr; });
 
               node.select(".g-failures circle")
-                .attr("clip-path", function(d) { return d.k > 0 ? "url(#g-clip-failure-" + d.dn + ")" : null; });
+                .attr("clip-path", function(d) { return d.k > 0 ? "url(#g-clip-failure-" + d.username + ")" : null; });
 
             node.exit().remove();
             force.start();
@@ -160,7 +159,8 @@ if (Meteor.isClient) {
         function tick(e) {
             var k = .1 * e.alpha;
 
-            // Push nodes toward their designated focus.
+            // Push nodes toward their designated focus
+            // based on ratio of success to failure
             nodes.forEach(function(o, i) {
               if (o.success > o.failures ){
                   o.y += (foci[0].y - o.y) * k;

--- a/meteor/server/methods.js
+++ b/meteor/server/methods.js
@@ -136,8 +136,8 @@ if (Meteor.isServer) {
     }
 
     function logincounts(){
-        //console.log('Calling ' + mozdef.rootAPI + '/ldapLogins/');
-        var logincountsResponse = HTTP.get(mozdef.rootAPI + '/ldapLogins/');
+        //console.log('Calling ' + mozdef.rootAPI + '/logincounts/');
+        var logincountsResponse = HTTP.get(mozdef.rootAPI + '/logincounts/');
 
         if ( typeof logincountsResponse == 'undefined') {
             console.log("logincountsResponse: no response from server")

--- a/rest/index.conf
+++ b/rest/index.conf
@@ -1,5 +1,5 @@
 [options]
 kibanaurl=http://localhost:9090/app/kibana
-esservers=http://localhost:9200
+esservers=http://elasticsearch:9200
 mongoport=3002
 listen_host=0.0.0.0

--- a/rest/index.conf
+++ b/rest/index.conf
@@ -1,5 +1,5 @@
 [options]
 kibanaurl=http://localhost:9090/app/kibana
-esservers=http://elasticsearch:9200
+esservers=http://localhost:9200
 mongoport=3002
 listen_host=0.0.0.0

--- a/rest/index.py
+++ b/rest/index.py
@@ -441,7 +441,7 @@ def registerPlugins():
                 if 'message' in dir(module):
                     mclass = module.message()
                     mreg = mclass.registration
-                    mclass.restoptions = options
+                    mclass.restoptions = options.__dict__
 
                     if 'priority' in dir(mclass):
                         mpriority = mclass.priority

--- a/rest/index.py
+++ b/rest/index.py
@@ -488,69 +488,6 @@ def isIPv4(ip):
     except:
         return False
 
-
-def esLdapResults(begindateUTC=None, enddateUTC=None):
-    '''an ES query/facet to count success/failed logins'''
-    resultsList = list()
-    if begindateUTC is None:
-        begindateUTC = datetime.now() - timedelta(hours=1)
-        begindateUTC = toUTC(begindateUTC)
-    if enddateUTC is None:
-        enddateUTC = datetime.now()
-        enddateUTC = toUTC(enddateUTC)
-
-    try:
-        es_client = ElasticsearchClient(list('{0}'.format(s) for s in options.esservers))
-        search_query = SearchQuery()
-        range_match = RangeMatch('utctimestamp', begindateUTC, enddateUTC)
-
-        search_query.add_must(range_match)
-        search_query.add_must(TermMatch('tags', 'ldap'))
-
-        search_query.add_must(TermMatch('details.result', 'LDAP_INVALID_CREDENTIALS'))
-
-        search_query.add_aggregation(Aggregation('details.result'))
-        search_query.add_aggregation(Aggregation('details.dn'))
-
-        results = search_query.execute(es_client, indices=['events'])
-
-        stoplist = ('o', 'mozilla', 'dc', 'com', 'mozilla.com', 'mozillafoundation.org', 'org', 'mozillafoundation')
-
-        for t in results['aggregations']['details.dn']['terms']:
-            if t['key'] in stoplist:
-                continue
-            failures = 0
-            success = 0
-            dn = t['key']
-
-            details_query = SearchQuery()
-            details_query.add_must(range_match)
-            details_query.add_must(TermMatch('tags', 'ldap'))
-            details_query.add_must(TermMatch('details.dn', dn))
-            details_query.add_aggregation(Aggregation('details.result'))
-
-            results = details_query.execute(es_client)
-
-            for t in results['aggregations']['details.result']['terms']:
-                if t['key'].upper() == 'LDAP_SUCCESS':
-                    success = t['count']
-                if t['key'].upper() == 'LDAP_INVALID_CREDENTIALS':
-                    failures = t['count']
-            resultsList.append(
-                dict(
-                    dn=dn,
-                    failures=failures,
-                    success=success,
-                    begin=begindateUTC.isoformat(),
-                    end=enddateUTC.isoformat()
-                )
-            )
-
-        return(json.dumps(resultsList))
-    except Exception as e:
-        sys.stderr.write('Error trying to get ldap results: {0}\n'.format(e))
-
-
 def kibanaDashboards():
     resultsList = []
     try:

--- a/rest/index.py
+++ b/rest/index.py
@@ -424,14 +424,20 @@ def generateMeteorID():
 
 
 def registerPlugins():
-    '''walk the ./plugins directory
+    '''walk the plugins directory
        and register modules in pluginList
        as a tuple: (mfile, mname, mdescription, mreg, mpriority, mclass)
     '''
 
+    plugin_location = os.path.join(os.path.dirname(__file__), "plugins")
+    module_name = os.path.basename(plugin_location)
+    root_plugin_directory = os.path.join(plugin_location, '..')
+
     plugin_manager = pynsive.PluginManager()
-    if os.path.exists('plugins'):
-        modules = pynsive.list_modules('plugins')
+    plugin_manager.plug_into(root_plugin_directory)
+
+    if os.path.exists(plugin_location):
+        modules = pynsive.list_modules(module_name)
         for mfile in modules:
             module = pynsive.import_module(mfile)
             reload(module)

--- a/rest/index.py
+++ b/rest/index.py
@@ -73,8 +73,8 @@ def status():
     return response
 
 
-@route('/ldapLogins')
-@route('/ldapLogins/')
+@route('/logincounts')
+@route('/logincounts/')
 @enable_cors
 def index():
     '''an endpoint to return success/failed login counts'''
@@ -82,8 +82,8 @@ def index():
         request.body.read()
         request.body.close()
     response.content_type = "application/json"
-    sendMessgeToPlugins(request, response, 'ldapLogins')
-    return(esLdapResults())
+    sendMessgeToPlugins(request, response, 'logincounts')
+    return response
 
 
 @route('/veris')

--- a/rest/index.py
+++ b/rest/index.py
@@ -488,6 +488,7 @@ def isIPv4(ip):
     except:
         return False
 
+
 def kibanaDashboards():
     resultsList = []
     try:

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -14,6 +14,7 @@ from mozdef_util.query_models import SearchQuery, TermMatch, TermsMatch, QuerySt
 from mozdef_util.utilities.toUTC import toUTC
 from mozdef_util.utilities.logger import logger, initLogger
 
+
 class message(object):
     def __init__(self):
         '''register our criteria for being passed a message

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -8,11 +8,11 @@ import json
 import os
 import sys
 from configlib import getConfig, OptionParser
+from datetime import datetime, timedelta
 from mozdef_util.elasticsearch_client import ElasticsearchClient, ElasticsearchInvalidIndex
 from mozdef_util.query_models import SearchQuery, TermMatch, TermsMatch, QueryStringMatch, RangeMatch, Aggregation, ExistsMatch
 from mozdef_util.utilities.toUTC import toUTC
 from mozdef_util.utilities.logger import logger, initLogger
-
 
 class message(object):
     def __init__(self):
@@ -54,16 +54,6 @@ class message(object):
         response: http://bottlepy.org/docs/dev/api.html#the-response-object
 
         '''
-        if request.body:
-            arequest = request.body.read()
-            request.body.close()
-        try:
-            requestDict = json.loads(arequest)
-        except ValueError as e:
-            response.status = 500
-
-        #print(requestDict, requestDict.keys())
-
         # an ES query/facet to count success/failed logins
         # oriented to the data sent via auth02mozdef.py
         begindateUTC=None

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -81,7 +81,7 @@ class message(object):
         # any usernames or words to ignore
         # especially useful if ES is analyzing the username field and breaking apart user@somewhere.com
         # into user somewhere and .com
-        stoplist =['']
+        stoplist =self.options.ignoreusernames.split(',')
         # walk the aggregate failed users
         # and look for successes/failures
         for t in results['aggregations']['details.username']['terms']:
@@ -127,6 +127,8 @@ class message(object):
         # fill self.options with plugin-specific options
 
         # options
+        # comma separated list of usernames to exclude
+        # from the data
         self.options.ignoreusernames = getConfig('ignoreusernames',
                                                  '',
                                                  self.configfile)

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -83,8 +83,6 @@ class message(object):
         # especially useful if ES is analyzing the username field and breaking apart user@somewhere.com
         # into user somewhere and .com
         stoplist =['']
-
-
         # walk the aggregate failed users
         # and look for successes/failures
         for t in results['aggregations']['details.username']['terms']:
@@ -117,7 +115,8 @@ class message(object):
                 )
             )
 
-        print(json.dumps(resultsList))
+        response.body = json.dumps(resultsList)
+        response.status = 200
 
         return (request, response)
 

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -45,7 +45,7 @@ class message(object):
         self.options = None
         if os.path.exists(self.configfile):
             sys.stdout.write('found conf file {0}\n'.format(self.configfile))
-            self.initConfiguration()
+        self.initConfiguration()
 
     def onMessage(self, request, response):
         '''

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -127,7 +127,7 @@ class message(object):
 
         # fill self.options with plugin-specific options
 
-        # cymon options
+        # options
         self.options.ignoreusernames = getConfig('ignoreusernames',
-                                             '',
-                                             self.configfile)
+                                                 '',
+                                                 self.configfile)

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -3,16 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
-import requests
 import json
 import os
 import sys
 from configlib import getConfig, OptionParser
 from datetime import datetime, timedelta
-from mozdef_util.elasticsearch_client import ElasticsearchClient, ElasticsearchInvalidIndex
-from mozdef_util.query_models import SearchQuery, TermMatch, TermsMatch, QueryStringMatch, RangeMatch, Aggregation, ExistsMatch
+from mozdef_util.elasticsearch_client import ElasticsearchClient
+from mozdef_util.query_models import SearchQuery, TermMatch, QueryStringMatch, RangeMatch, Aggregation, ExistsMatch
 from mozdef_util.utilities.toUTC import toUTC
-from mozdef_util.utilities.logger import logger, initLogger
 
 
 class message(object):

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -1,0 +1,144 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+
+import requests
+import json
+import os
+import sys
+from configlib import getConfig, OptionParser
+from mozdef_util.elasticsearch_client import ElasticsearchClient, ElasticsearchInvalidIndex
+from mozdef_util.query_models import SearchQuery, TermMatch, TermsMatch, QueryStringMatch, RangeMatch, Aggregation, ExistsMatch
+from mozdef_util.utilities.toUTC import toUTC
+from mozdef_util.utilities.logger import logger, initLogger
+
+
+class message(object):
+    def __init__(self):
+        '''register our criteria for being passed a message
+           as a list of lower case strings to match with an rest endpoint
+           (i.e. blockip matches /blockip)
+           set the priority if you have a preference for order of plugins
+           0 goes first, 100 is assumed/default if not sent
+
+           Plugins will register in Meteor with attributes:
+           name: (as below)
+           description: (as below)
+           priority: (as below)
+           file: "plugins.filename" where filename.py is the plugin code.
+
+           Plugin gets sent main rest options as:
+           self.restoptions
+           self.restoptions['configfile'] will be the .conf file
+           used by the restapi's index.py file.
+
+        '''
+
+        self.registration = ['logincounts']
+        self.priority = 5
+        self.name = "auth0LoginCounts"
+        self.description = "count failures/success logins"
+
+        # set my own conf file
+        # relative path to the rest index.py file
+        self.configfile = './plugins/auth0_logincounts.conf'
+        self.options = None
+        if os.path.exists(self.configfile):
+            sys.stdout.write('found conf file {0}\n'.format(self.configfile))
+            self.initConfiguration()
+
+    def onMessage(self, request, response):
+        '''
+        request: http://bottlepy.org/docs/dev/api.html#the-request-object
+        response: http://bottlepy.org/docs/dev/api.html#the-response-object
+
+        '''
+        if request.body:
+            arequest = request.body.read()
+            request.body.close()
+        try:
+            requestDict = json.loads(arequest)
+        except ValueError as e:
+            response.status = 500
+
+        #print(requestDict, requestDict.keys())
+
+        # an ES query/facet to count success/failed logins
+        # oriented to the data sent via auth02mozdef.py
+        begindateUTC=None
+        enddateUTC=None
+        resultsList = list()
+        if begindateUTC is None:
+            begindateUTC = datetime.now() - timedelta(hours=12)
+            begindateUTC = toUTC(begindateUTC)
+        if enddateUTC is None:
+            enddateUTC = datetime.now()
+            enddateUTC = toUTC(enddateUTC)
+
+        es_client = ElasticsearchClient(list('{0}'.format(s) for s in options['esservers']))
+        search_query = SearchQuery()
+        # a query to tally users with failed logins
+        date_range_match = RangeMatch('utctimestamp', begindateUTC, enddateUTC)
+        search_query.add_must(date_range_match)
+        search_query.add_must(TermMatch('tags', 'auth0'))
+        search_query.add_must(QueryStringMatch('failed'))
+        search_query.add_must(ExistsMatch('details.username'))
+        search_query.add_aggregation(Aggregation('details.type'))
+        search_query.add_aggregation(Aggregation('details.username'))
+
+        results = search_query.execute(es_client, indices=['events','events-previous'])
+
+        # any usernames or words to ignore
+        # especially useful if ES is analyzing the username field and breaking apart user@somewhere.com
+        # into user somewhere and .com
+        stoplist =['']
+
+
+        # walk the aggregate failed users
+        # and look for successes/failures
+        for t in results['aggregations']['details.username']['terms']:
+            if t['key'] in stoplist:
+                continue
+            failures = 0
+            success = 0
+            username = t['key']
+
+            details_query = SearchQuery()
+            details_query.add_must(date_range_match)
+            details_query.add_must(TermMatch('tags', 'auth0'))
+            details_query.add_must(TermMatch('details.username', username))
+            details_query.add_aggregation(Aggregation('details.type'))
+
+            results = details_query.execute(es_client)
+            # details.type is usually "Success Login" or "Failed Login"
+            for t in results['aggregations']['details.type']['terms']:
+                if 'success' in t['key'].lower():
+                    success = t['count']
+                if 'fail' in t['key'].lower():
+                    failures = t['count']
+            resultsList.append(
+                dict(
+                    username=username,
+                    failures=failures,
+                    success=success,
+                    begin=begindateUTC.isoformat(),
+                    end=enddateUTC.isoformat()
+                )
+            )
+
+        print(json.dumps(resultsList))
+
+        return (request, response)
+
+    def initConfiguration(self):
+        myparser = OptionParser()
+        # setup self.options by sending empty list [] to parse_args
+        (self.options, args) = myparser.parse_args([])
+
+        # fill self.options with plugin-specific options
+
+        # cymon options
+        self.options.ignoreusernames = getConfig('ignoreusernames',
+                                             '',
+                                             self.configfile)

--- a/rest/plugins/auth0_logincounts.py
+++ b/rest/plugins/auth0_logincounts.py
@@ -76,7 +76,7 @@ class message(object):
             enddateUTC = datetime.now()
             enddateUTC = toUTC(enddateUTC)
 
-        es_client = ElasticsearchClient(list('{0}'.format(s) for s in options['esservers']))
+        es_client = ElasticsearchClient(list('{0}'.format(s) for s in self.restoptions['esservers']))
         search_query = SearchQuery()
         # a query to tally users with failed logins
         date_range_match = RangeMatch('utctimestamp', begindateUTC, enddateUTC)

--- a/tests/loginput/loginput_index.conf
+++ b/tests/loginput/loginput_index.conf
@@ -1,0 +1,4 @@
+[options]
+mquser=guest
+mqpassword=guest
+listen_host=127.0.0.1

--- a/tests/loginput/loginput_test_suite.py
+++ b/tests/loginput/loginput_test_suite.py
@@ -14,7 +14,7 @@ class LoginputTestSuite(HTTPTestSuite):
 
     def setup(self):
         sample_config = DotDict()
-        sample_config.configfile = os.path.join(os.path.dirname(__file__), '../../loginput/index.conf')
+        sample_config.configfile = os.path.join(os.path.dirname(__file__), 'loginput_index.conf')
         OptionParser.parse_args = mock.Mock(return_value=(sample_config, {}))
         from loginput import index
         self.application = index.application

--- a/tests/rest/rest_index.conf
+++ b/tests/rest/rest_index.conf
@@ -1,0 +1,5 @@
+[options]
+kibanaurl=http://localhost:9090/app/kibana
+esservers=http://elasticsearch:9200
+mongoport=3002
+listen_host=0.0.0.0

--- a/tests/rest/rest_test_suite.py
+++ b/tests/rest/rest_test_suite.py
@@ -10,11 +10,17 @@ import mock
 from configlib import OptionParser
 
 
+class RestTestDict(DotDict):
+    @property
+    def __dict__(self):
+        return self
+
+
 class RestTestSuite(HTTPTestSuite):
 
     def setup(self):
-        sample_config = DotDict()
-        sample_config.configfile = os.path.join(os.path.dirname(__file__), '../../rest/index.conf')
+        sample_config = RestTestDict()
+        sample_config.configfile = os.path.join(os.path.dirname(__file__), 'rest_index.conf')
         OptionParser.parse_args = mock.Mock(return_value=(sample_config, {}))
 
         from rest import index

--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -240,7 +240,7 @@ class TestLdapLoginsRoute(RestTestSuite):
             assert json_resp[0].keys() == ['username', 'failures', 'begin', 'end', 'success']
             assert json_resp[0]['username'] == 'qwerty@mozillafoundation.org'
             assert json_resp[0]['failures'] == 8
-            assert json_resp[0]['success'] == 3
+            assert json_resp[0]['success'] == 6
             assert type(json_resp[0]['begin']) == unicode
             assert parse(json_resp[0]['begin']).tzname() == 'UTC'
             assert type(json_resp[0]['end']) == unicode

--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -238,7 +238,7 @@ class TestLdapLoginsRoute(RestTestSuite):
             json_resp.sort()
 
             assert json_resp[0].keys() == ['username', 'failures', 'begin', 'end', 'success']
-            assert json_resp[0]['username'] == 'qwerty@mozillafoundation.org,o=org,dc=mozillafoundation'
+            assert json_resp[0]['username'] == 'qwerty@mozillafoundation.org'
             assert json_resp[0]['failures'] == 8
             assert json_resp[0]['success'] == 3
             assert type(json_resp[0]['begin']) == unicode
@@ -247,7 +247,7 @@ class TestLdapLoginsRoute(RestTestSuite):
             assert parse(json_resp[0]['begin']).tzname() == 'UTC'
 
             assert json_resp[1].keys() == ['username', 'failures', 'begin', 'end', 'success']
-            assert json_resp[1]['username'] == 'ttester@mozilla.com,o=com,dc=mozilla'
+            assert json_resp[1]['username'] == 'ttester@mozilla.com'
             assert json_resp[1]['failures'] == 9
             assert json_resp[1]['success'] == 7
             assert type(json_resp[1]['begin']) == unicode
@@ -256,7 +256,7 @@ class TestLdapLoginsRoute(RestTestSuite):
             assert parse(json_resp[1]['begin']).tzname() == 'UTC'
 
             assert json_resp[2].keys() == ['username', 'failures', 'begin', 'end', 'success']
-            assert json_resp[2]['username'] == 'ttesterson@mozilla.com,o=com,dc=mozilla'
+            assert json_resp[2]['username'] == 'ttesterson@mozilla.com'
             assert json_resp[2]['failures'] == 10
             assert json_resp[2]['success'] == 5
             assert type(json_resp[2]['begin']) == unicode

--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -161,7 +161,7 @@ class TestLdapLoginsRoute(RestTestSuite):
                 "receivedtimestamp": timestamp,
                 "utctimestamp": timestamp,
                 "tags": [
-                    "ldap"
+                    "auth0"
                 ],
                 "timestamp": timestamp,
                 "summary": "Success Login for ttester@mozilla.com srcIP=1.1.1.1",
@@ -179,7 +179,7 @@ class TestLdapLoginsRoute(RestTestSuite):
                 "receivedtimestamp": timestamp,
                 "utctimestamp": timestamp,
                 "tags": [
-                    "ldap"
+                    "auth0"
                 ],
                 "timestamp": timestamp,
                 "summary": "Failed Login from qwerty@mozillafoundation.org srcIP=1.1.1.1",
@@ -195,7 +195,7 @@ class TestLdapLoginsRoute(RestTestSuite):
                 "receivedtimestamp": timestamp,
                 "utctimestamp": timestamp,
                 "tags": [
-                    "ldap"
+                    "auth0"
                 ],
                 "timestamp": timestamp,
                 "summary": "Success Login for qwerty@mozillafoundation.org",
@@ -212,7 +212,7 @@ class TestLdapLoginsRoute(RestTestSuite):
                 "receivedtimestamp": timestamp,
                 "utctimestamp": timestamp,
                 "tags": [
-                    "ldap"
+                    "auth0"
                 ],
                 "timestamp": timestamp,
                 "summary": "Success Login for qwerty@mozillafoundation.org",

--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -207,7 +207,7 @@ class TestLdapLoginsRoute(RestTestSuite):
             self.populate_test_event(event)
 
         for count in range(3):
-            timestamp = RestTestSuite.subtract_from_timestamp({'hours': 2})
+            timestamp = RestTestSuite.subtract_from_timestamp({'hours': 22})
             event = {
                 "receivedtimestamp": timestamp,
                 "utctimestamp": timestamp,
@@ -240,7 +240,7 @@ class TestLdapLoginsRoute(RestTestSuite):
             assert json_resp[0].keys() == ['username', 'failures', 'begin', 'end', 'success']
             assert json_resp[0]['username'] == 'qwerty@mozillafoundation.org'
             assert json_resp[0]['failures'] == 8
-            assert json_resp[0]['success'] == 6
+            assert json_resp[0]['success'] == 3
             assert type(json_resp[0]['begin']) == unicode
             assert parse(json_resp[0]['begin']).tzname() == 'UTC'
             assert type(json_resp[0]['end']) == unicode

--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -98,7 +98,7 @@ class TestKibanaDashboardsRouteWithoutDashboards(RestTestSuite):
 
 class TestLdapLoginsRoute(RestTestSuite):
 
-    routes = ['/ldapLogins', '/ldapLogins/']
+    routes = ['/logincounts', '/logincounts/']
     status_code = 200
 
     def setup(self):
@@ -111,13 +111,13 @@ class TestLdapLoginsRoute(RestTestSuite):
                 "receivedtimestamp": timestamp,
                 "utctimestamp": timestamp,
                 "tags": [
-                    "ldap"
+                    "auth0"
                 ],
                 "timestamp": timestamp,
-                "summary": "LDAP_INVALID_CREDENTIALS ttesterson@mozilla.com,o=com,dc=mozilla srcIP=1.1.1.1",
+                "summary": "Failed login from ttesterson@mozilla.com srcIP=1.1.1.1",
                 "details": {
-                    "dn": "ttesterson@mozilla.com,o=com,dc=mozilla",
-                    "result": "LDAP_INVALID_CREDENTIALS",
+                    "username": "ttesterson@mozilla.com",
+                    "type": "Failed Login",
                 }
             }
             self.populate_test_event(event)
@@ -127,13 +127,13 @@ class TestLdapLoginsRoute(RestTestSuite):
                 "receivedtimestamp": timestamp,
                 "utctimestamp": timestamp,
                 "tags": [
-                    "ldap"
+                    "auth0"
                 ],
                 "timestamp": timestamp,
-                "summary": "LDAP_SUCCESS ttesterson@mozilla.com,o=com,dc=mozilla srcIP=1.1.1.1",
+                "summary": "Success Login for ttesterson@mozilla.com srcIP=1.1.1.1",
                 "details": {
-                    "dn": "ttesterson@mozilla.com,o=com,dc=mozilla",
-                    "result": "LDAP_SUCCESS",
+                    "username": "ttesterson@mozilla.com",
+                    "type": "Success Login",
                 }
             }
             self.populate_test_event(event)
@@ -145,13 +145,13 @@ class TestLdapLoginsRoute(RestTestSuite):
                 "receivedtimestamp": timestamp,
                 "utctimestamp": timestamp,
                 "tags": [
-                    "ldap"
+                    "auth0"
                 ],
                 "timestamp": timestamp,
-                "summary": "LDAP_INVALID_CREDENTIALS ttester@mozilla.com,o=com,dc=mozilla srcIP=1.1.1.1",
+                "summary": "Failed Login from ttester@mozilla.com srcIP=1.1.1.1",
                 "details": {
-                    "dn": "ttester@mozilla.com,o=com,dc=mozilla",
-                    "result": "LDAP_INVALID_CREDENTIALS",
+                    "username": "ttester@mozilla.com",
+                    "type": "Failed Login",
                 }
             }
             self.populate_test_event(event)
@@ -164,10 +164,10 @@ class TestLdapLoginsRoute(RestTestSuite):
                     "ldap"
                 ],
                 "timestamp": timestamp,
-                "summary": "LDAP_SUCCESS ttester@mozilla.com,o=com,dc=mozilla srcIP=1.1.1.1",
+                "summary": "Success Login for ttester@mozilla.com srcIP=1.1.1.1",
                 "details": {
-                    "dn": "ttester@mozilla.com,o=com,dc=mozilla",
-                    "result": "LDAP_SUCCESS",
+                    "username": "ttester@mozilla.com",
+                    "type": "Success Login",
                 }
             }
             self.populate_test_event(event)
@@ -182,10 +182,10 @@ class TestLdapLoginsRoute(RestTestSuite):
                     "ldap"
                 ],
                 "timestamp": timestamp,
-                "summary": "LDAP_INVALID_CREDENTIALS qwerty@mozillafoundation.org,o=org,dc=mozillafoundation srcIP=1.1.1.1",
+                "summary": "Failed Login from qwerty@mozillafoundation.org srcIP=1.1.1.1",
                 "details": {
-                    "dn": "qwerty@mozillafoundation.org,o=org,dc=mozillafoundation",
-                    "result": "LDAP_INVALID_CREDENTIALS",
+                    "username": "qwerty@mozillafoundation.org",
+                    "type": "Failed Login",
                 }
             }
             self.populate_test_event(event)
@@ -198,10 +198,10 @@ class TestLdapLoginsRoute(RestTestSuite):
                     "ldap"
                 ],
                 "timestamp": timestamp,
-                "summary": "LDAP_SUCCESS qwerty@mozillafoundation.org,o=org,dc=mozillafoundation",
+                "summary": "Success Login for qwerty@mozillafoundation.org",
                 "details": {
-                    "dn": "qwerty@mozillafoundation.org,o=org,dc=mozillafoundation",
-                    "result": "LDAP_SUCCESS",
+                    "username": "qwerty@mozillafoundation.org",
+                    "type": "Success Login",
                 }
             }
             self.populate_test_event(event)
@@ -215,10 +215,10 @@ class TestLdapLoginsRoute(RestTestSuite):
                     "ldap"
                 ],
                 "timestamp": timestamp,
-                "summary": "LDAP_SUCCESS qwerty@mozillafoundation.org,o=org,dc=mozillafoundation",
+                "summary": "Success Login for qwerty@mozillafoundation.org",
                 "details": {
-                    "dn": "qwerty@mozillafoundation.org,o=org,dc=mozillafoundation",
-                    "result": "LDAP_SUCCESS",
+                    "username": "qwerty@mozillafoundation.org",
+                    "type": "Success Login",
                 }
             }
             self.populate_test_event(event)
@@ -237,8 +237,8 @@ class TestLdapLoginsRoute(RestTestSuite):
 
             json_resp.sort()
 
-            assert json_resp[0].keys() == ['dn', 'failures', 'begin', 'end', 'success']
-            assert json_resp[0]['dn'] == 'qwerty@mozillafoundation.org,o=org,dc=mozillafoundation'
+            assert json_resp[0].keys() == ['username', 'failures', 'begin', 'end', 'success']
+            assert json_resp[0]['username'] == 'qwerty@mozillafoundation.org,o=org,dc=mozillafoundation'
             assert json_resp[0]['failures'] == 8
             assert json_resp[0]['success'] == 3
             assert type(json_resp[0]['begin']) == unicode
@@ -246,8 +246,8 @@ class TestLdapLoginsRoute(RestTestSuite):
             assert type(json_resp[0]['end']) == unicode
             assert parse(json_resp[0]['begin']).tzname() == 'UTC'
 
-            assert json_resp[1].keys() == ['dn', 'failures', 'begin', 'end', 'success']
-            assert json_resp[1]['dn'] == 'ttester@mozilla.com,o=com,dc=mozilla'
+            assert json_resp[1].keys() == ['username', 'failures', 'begin', 'end', 'success']
+            assert json_resp[1]['username'] == 'ttester@mozilla.com,o=com,dc=mozilla'
             assert json_resp[1]['failures'] == 9
             assert json_resp[1]['success'] == 7
             assert type(json_resp[1]['begin']) == unicode
@@ -255,8 +255,8 @@ class TestLdapLoginsRoute(RestTestSuite):
             assert type(json_resp[1]['end']) == unicode
             assert parse(json_resp[1]['begin']).tzname() == 'UTC'
 
-            assert json_resp[2].keys() == ['dn', 'failures', 'begin', 'end', 'success']
-            assert json_resp[2]['dn'] == 'ttesterson@mozilla.com,o=com,dc=mozilla'
+            assert json_resp[2].keys() == ['username', 'failures', 'begin', 'end', 'success']
+            assert json_resp[2]['username'] == 'ttesterson@mozilla.com,o=com,dc=mozilla'
             assert json_resp[2]['failures'] == 10
             assert json_resp[2]['success'] == 5
             assert type(json_resp[2]['begin']) == unicode


### PR DESCRIPTION
Update the logincounts function to recent versions of events/endpoints, etc. 

This targets the current auth0 events, instead of the historical ldap events.

Ideally 'authentication' events are generic with category: authentication, details.success as true/false, details.username as the userid in question, etc. 

This PR is a first step in making this count/visualization generic.

