### PR TITLE
Modify alert test suite to bubble up exceptions

### DIFF
--- a/alerts/lib/alerttask.py
+++ b/alerts/lib/alerttask.py
@@ -435,7 +435,7 @@ class AlertTask(Task):
             self.main(*args, **kwargs)
             self.log.debug('finished')
         except Exception as e:
-            self.log.error('Exception in main() method: {0}'.format(e))
+            self.log.exception('Exception in main() method: {0}'.format(e))
 
     def parse_json_alert_config(self, config_file):
         """

--- a/tests/alerts/alert_test_suite.py
+++ b/tests/alerts/alert_test_suite.py
@@ -7,6 +7,7 @@
 
 import os.path
 import sys
+import logging
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
 
@@ -69,6 +70,10 @@ class AlertTestSuite(UnitTestSuite):
         # Meaning, this will throw if no events are found
         if not hasattr(self, 'deadman'):
             self.deadman = False
+
+        # Log to stdout so pytest will report any
+        # stack traces on any test failures
+        logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
 
     # Some housekeeping stuff here to make sure the data we get is 'good'
     def verify_starting_values(self, test_case):


### PR DESCRIPTION
This bubbles up any exceptions in the unit tests like so
```
../tests/alerts/alert_test_suite.py:151: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test_proxy_drop_ip.TestAlertProxyDropIP object at 0x10c06b690>, alert_task = <@task: None of None>, test_case = <positive_alert_test_case.PositiveAlertTestCase object at 0x10bd51ed0>

    def verify_alert_task(self, alert_task, test_case):
        assert alert_task.classname() == self.alert_classname, 'Alert classname did not match expected name'
        if test_case.expected_test_result is True:
>           assert len(alert_task.alert_ids) is not 0, 'Alert did not fire as expected'
E           AssertionError: Alert did not fire as expected

../tests/alerts/alert_test_suite.py:212: AssertionError
---------------------------------------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------------------------------------
ERROR:lib.alerttask.AlertProxyDropIP:Exception in main() method: global name 'asdasdf' is not defined
Traceback (most recent call last):
  File "/Users/bmyers/src/mozdef-env/src/MozDef/tests/alerts/../../alerts/lib/alerttask.py", line 435, in run
    self.main(*args, **kwargs)
  File "/Users/bmyers/src/mozdef-env/src/MozDef/tests/alerts/../../alerts/proxy_drop_ip.py", line 17, in main
    asdasdf
NameError: global name 'asdasdf' is not defined
```