### PR TITLE
Modify tester container to copy all python directories for pep8

### DIFF
--- a/docker/compose/tester/Dockerfile
+++ b/docker/compose/tester/Dockerfile
@@ -1,11 +1,14 @@
 FROM mozdef/mozdef_base
 
-COPY tests /opt/mozdef/envs/mozdef/tests
 COPY alerts /opt/mozdef/envs/mozdef/alerts
-COPY mq /opt/mozdef/envs/mozdef/mq
-COPY loginput /opt/mozdef/envs/mozdef/loginput
-COPY rest /opt/mozdef/envs/mozdef/rest
+COPY bot /opt/mozdef/envs/mozdef/bot
 COPY cron /opt/mozdef/envs/mozdef/cron
+COPY examples /opt/mozdef/envs/mozdef/examples
+COPY loginput /opt/mozdef/envs/mozdef/loginput
+COPY mozdef_util /opt/mozdef/envs/mozdef/mozdef_util
+COPY mq /opt/mozdef/envs/mozdef/mq
+COPY rest /opt/mozdef/envs/mozdef/rest
+COPY tests /opt/mozdef/envs/mozdef/tests
 COPY .flake8 /opt/mozdef/envs/mozdef/.flake8
 
 COPY docker/compose/tester/files/tests_config.conf /opt/mozdef/envs/mozdef/tests/config.conf


### PR DESCRIPTION
This is to ensure every python file will have pep8 checks ran against it. I also alphabetically ordered the directory names.