### PR TITLE
Add GuardDuty findings collection to AWS MozDef

### DIFF
--- a/alerts/guard_duty_probe.py
+++ b/alerts/guard_duty_probe.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+
+
+from lib.alerttask import AlertTask
+from mozdef_util.query_models import SearchQuery, TermMatch, QueryStringMatch, ExistsMatch, PhraseMatch, WildcardMatch
+
+
+class AlertGuardDutyProbe(AlertTask):
+    def main(self):
+        # Create a query to look back the last 20 minutes
+        search_query = SearchQuery(minutes=20)
+
+        # Add search terms to our query
+        search_query.add_must([
+            TermMatch('source', 'guardduty'),
+            TermMatch('details.finding.action.actionType', 'PORT_PROBE'),
+            ExistsMatch('details.sourceipaddress'),
+        ])
+
+        self.filtersManual(search_query)
+        # Search aggregations on field 'sourceipaddress'
+        # keep X samples of events at most
+        self.searchEventsAggregated('details.sourceipaddress', samplesLimit=10)
+        # alert when >= X matching events in an aggregation
+        self.walkAggregations(threshold=1)
+
+    # Set alert properties
+    def onAggregation(self, aggreg):
+        # aggreg['count']: number of items in the aggregation, ex: number of failed login attempts
+        # aggreg['value']: value of the aggregation field, ex: toto@example.com
+        # aggreg['events']: list of events in the aggregation
+        category = 'bruteforce'
+        tags = ['guardduty', 'bruteforce']
+        severity = 'INFO'
+        summary = "Guard Duty Port Probe by {}".format(aggreg['value'])
+
+        # Create the alert object based on these properties
+        return self.createAlertDict(summary, category, tags, aggreg['events'], severity)

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -71,6 +71,9 @@ Parameters:
   MozDefSQSQueueName:
     Type: String
     Description: The name of the generic SQS queue used to pickup events.
+  DomainName:
+    Type: String
+    Description: The fully qualified domain you'll be hosting MozDef at.
 Resources:
   MozDefElasticLoadBalancingV2TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -119,7 +122,8 @@ Resources:
             - content: |
                 OPTIONS_ESSERVERS=${ESURL}
                 OPTIONS_KIBANAURL=${KibanaURL}
-                OPTIONS_METEOR_KIBANAURL=https://relative:9090/_plugin/kibana/
+                OPTIONS_METEOR_KIBANAURL=https://relative:9090/_plugin/kibana/ # not a typo needed for meteor
+                OPTIONS_METEOR_ROOTURL=https://${DomainName}
                 # See https://github.com/mozilla-iam/mozilla.oidc.accessproxy/blob/master/README.md#setup
                 client_id=${OIDCClientId}
                 client_secret=${OIDCClientSecret}
@@ -136,8 +140,10 @@ Resources:
                 cookiename=sesmeteor
                 # Increase the AWS ES total fields limit from 1000 to 4000
                 OPTIONS_MAPPING_TOTAL_FIELDS_LIMIT=4000
+                # Set thresholds for attack dataviz lower means more ogres
+                OPTIONS_IPV4ATTACKERHITCOUNT=5
+                OPTIONS_IPV4ATTACKERPREFIXLENGTH=24
               path: /opt/mozdef/docker/compose/cloudy_mozdef.env
-          write_files:
             - content: |
                 #!/usr/bin/env python
                 # This Source Code Form is subject to the terms of the Mozilla Public
@@ -152,7 +158,7 @@ Resources:
                 ALERTS = {
                     'bruteforce_ssh.AlertBruteforceSsh': {'schedule': crontab(minute='*/1')},
                     'unauth_ssh.AlertUnauthSSH': {'schedule': crontab(minute='*/1')},
-                    'guard_duty_probe.AlertGuardDutyProbe': {'schedule': crontab(minute='*/1')}',
+                    'guard_duty_probe.AlertGuardDutyProbe': {'schedule': crontab(minute='*/1')},
                     'cloudtrail_logging_disabled.AlertCloudtrailLoggingDisabled': {'schedule': timedelta(minutes=1)},
                     'cloudtrail_deadman.AlertCloudtrailDeadman': {'schedule': timedelta(hours=1)}
                 }
@@ -171,7 +177,7 @@ Resources:
                 }
 
                 ES = {
-                    'servers': [${ESURL}]
+                    'servers': ["${ESURL}"]
                 }
 
                 OPTIONS = {

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -152,7 +152,7 @@ Resources:
                 ALERTS = {
                     'bruteforce_ssh.AlertBruteforceSsh': {'schedule': crontab(minute='*/1')},
                     'unauth_ssh.AlertUnauthSSH': {'schedule': crontab(minute='*/1')},
-                    'guard_duty_probe.AlertGuardDutyProbe: {'schedule': crontab(minute='*/1')}',
+                    'guard_duty_probe.AlertGuardDutyProbe': {'schedule': crontab(minute='*/1')}',
                     'cloudtrail_logging_disabled.AlertCloudtrailLoggingDisabled': {'schedule': timedelta(minutes=1)},
                     'cloudtrail_deadman.AlertCloudtrailDeadman': {'schedule': timedelta(hours=1)}
                 }

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -122,7 +122,9 @@ Resources:
             - content: |
                 OPTIONS_ESSERVERS=${ESURL}
                 OPTIONS_KIBANAURL=${KibanaURL}
-                OPTIONS_METEOR_KIBANAURL=https://relative:9090/_plugin/kibana/ # not a typo needed for meteor
+                # The OPTIONS_METEOR_KIBANAURL uses the reserved word "relative" which triggers MozDef
+                # to use relative links to Kibana : https://github.com/mozilla/MozDef/pull/956
+                OPTIONS_METEOR_KIBANAURL=https://relative:9090/_plugin/kibana/
                 OPTIONS_METEOR_ROOTURL=https://${DomainName}
                 # See https://github.com/mozilla-iam/mozilla.oidc.accessproxy/blob/master/README.md#setup
                 client_id=${OIDCClientId}

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -137,6 +137,83 @@ Resources:
                 # Increase the AWS ES total fields limit from 1000 to 4000
                 OPTIONS_MAPPING_TOTAL_FIELDS_LIMIT=4000
               path: /opt/mozdef/docker/compose/cloudy_mozdef.env
+          write_files:
+            - content: |
+                #!/usr/bin/env python
+                # This Source Code Form is subject to the terms of the Mozilla Public
+                # License, v. 2.0. If a copy of the MPL was not distributed with this
+                # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+                # Copyright (c) 2014 Mozilla Corporation
+
+                from celery.schedules import crontab, timedelta
+                import time
+                import logging
+
+                ALERTS = {
+                    'bruteforce_ssh.AlertBruteforceSsh': {'schedule': crontab(minute='*/1')},
+                    'unauth_ssh.AlertUnauthSSH': {'schedule': crontab(minute='*/1')},
+                    'guard_duty_probe.AlertGuardDutyProbe: {'schedule': crontab(minute='*/1')}',
+                    'cloudtrail_logging_disabled.AlertCloudtrailLoggingDisabled': {'schedule': timedelta(minutes=1)},
+                    'cloudtrail_deadman.AlertCloudtrailDeadman': {'schedule': timedelta(hours=1)}
+                }
+
+                ALERT_PLUGINS = [
+                    # 'relative pythonfile name (exclude the .py) - EX: sso_dashboard',
+                ]
+
+                RABBITMQ = {
+                    'mqserver': 'rabbitmq',
+                    'mquser': 'guest',
+                    'mqpassword': 'guest',
+                    'mqport': 5672,
+                    'alertexchange': 'alerts',
+                    'alertqueue': 'mozdef.alert'
+                }
+
+                ES = {
+                    'servers': [${ESURL}]
+                }
+
+                OPTIONS = {
+                    'defaulttimezone': 'UTC',
+                }
+
+                LOGGING = {
+                    'version': 1,
+                    'disable_existing_loggers': True,
+                    'formatters': {
+                        'simple': {
+                            'format': '%(levelname)s %(message)s',
+                            'datefmt': '%y %b %d, %H:%M:%S',
+                        },
+                        'standard': {
+                            'format': '%(asctime)s [%(levelname)s] %(name)s %(filename)s:%(lineno)d: %(message)s'
+                        }
+                    },
+                    'handlers': {
+                        'console': {
+                            'level': 'DEBUG',
+                            'class': 'logging.StreamHandler',
+                            'formatter': 'simple'
+                        },
+                        'celery': {
+                            'level': 'DEBUG',
+                            'class': 'logging.handlers.RotatingFileHandler',
+                            'filename': 'celery.log',
+                            'formatter': 'standard',
+                            'maxBytes': 1024 * 1024 * 100,  # 100 mb
+                        },
+                    },
+                    'loggers': {
+                        'celery': {
+                            'handlers': ['celery', 'console'],
+                            'level': 'DEBUG',
+                        },
+                    }
+                }
+
+                logging.Formatter.converter = time.gmtime
+              path: /opt/mozdef/docker/compose/mozdef_alerts/files/config.py
             - content: |
                 client_id=${OIDCClientId}
                 client_secret=${OIDCClientSecret}

--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -15,6 +15,10 @@ Metadata:
       - KeyName
       - AMIImageId
 Parameters:
+  DomainName:
+    Type: String
+    Description: The fully qualified DNS name you will host CloudyMozDef at.
+    Default: cloudymozdef.security.allizom.org
   S3TemplateLocation:
     Type: String
     Description: The URL to the S3 bucket used to fetch the nested stack templates
@@ -38,7 +42,7 @@ Parameters:
   AMIImageId:
     Type: String
     Description: The AMI Image ID to use of the EC2 instance
-    Default: ami-0c3705bb3b43ad51f
+    Default: ami-073434079b0366251
   ACMCertArn:
     Description: The ARN of your pre-issued ACM cert.
     Default : arn:aws:acm:us-west-2:656532927350:certificate/79f641f2-4046-4754-a28f-4db80d7c0583
@@ -99,6 +103,7 @@ Resources:
         OIDCDiscoveryURL: !Ref OIDCDiscoveryURL
         CloudTrailSQSNotificationQueueName: !GetAtt MozDefCloudTrail.Outputs.CloudTrailSQSQueueName
         MozDefSQSQueueName: !GetAtt MozDefSQS.Outputs.SQSQueueName
+        DomainName: !Ref DomainName
       Tags:
         - Key: application
           Value: mozdef

--- a/cloudy_mozdef/packer/packer.json
+++ b/cloudy_mozdef/packer/packer.json
@@ -33,7 +33,7 @@
         "sudo systemctl enable docker",
         "sudo mkdir -p /opt/mozdef/",
         "sudo git clone https://github.com/mozilla/MozDef /opt/mozdef",
-        "cd /opt/mozdef && sudo git checkout reinvent"
+        "cd /opt/mozdef && sudo git checkout master"
       ]}
  ]
 }

--- a/cloudy_mozdef/packer/packer.json
+++ b/cloudy_mozdef/packer/packer.json
@@ -14,7 +14,10 @@
     "instance_type": "t2.large",
     "ssh_pty" : "true",
     "ssh_username": "ec2-user",
-    "ami_name": "mozdef_{{timestamp}}"
+    "ami_name": "mozdef_{{timestamp}}",
+    "ami_groups": [
+      "all"
+    ]
   }],
  "provisioners": [
    {  "type": "shell",
@@ -30,7 +33,7 @@
         "sudo systemctl enable docker",
         "sudo mkdir -p /opt/mozdef/",
         "sudo git clone https://github.com/mozilla/MozDef /opt/mozdef",
-        "cd /opt/mozdef && sudo git checkout guardduty"
+        "cd /opt/mozdef && sudo git checkout reinvent"
       ]}
  ]
 }

--- a/cron/collectAttackers.py
+++ b/cron/collectAttackers.py
@@ -153,7 +153,7 @@ def searchMongoAlerts(mozdefdb):
         # count by ip
         {"$group": {"_id": "$sourceip", "hitcount": {"$sum": 1}}},
         # limit to those with X observances
-        {"$match": {"hitcount": {"$gt": 5}}},
+        {"$match": {"hitcount": {"$gt": options.ipv4attackerhitcount}}},
         # sort
         {"$sort": SON([("hitcount", -1), ("_id", -1)])},
         # top 10
@@ -166,7 +166,7 @@ def searchMongoAlerts(mozdefdb):
             # set CIDR
             # todo: lookup ipwhois for asn_cidr value
             # potentially with a max mask value (i.e. asn is /8, limit attackers to /24)
-            ipcidr.prefixlen = 32
+            ipcidr.prefixlen = options.ipv4attackerprefixlength
 
             # append to or create attacker.
             # does this match an existing attacker's indicators
@@ -481,6 +481,11 @@ def initConfig():
     options.mqvhost = getConfig('mqvhost', '/', options.configfile)
     # set to either amqp or amqps for ssl
     options.mqprotocol = getConfig('mqprotocol', 'amqp', options.configfile)
+
+    # Set these settings to change the correlation for attackers
+    options.ipv4attackerprefixlength = getConfig('ipv4attackerprefixlength', 32, options.configfile)
+    options.ipv4attackerhitcount = getConfig('ipv4ipv4attackerhitcount', 5, options.configfile)
+
 
 
 if __name__ == '__main__':

--- a/cron/collectAttackers.py
+++ b/cron/collectAttackers.py
@@ -487,7 +487,6 @@ def initConfig():
     options.ipv4attackerhitcount = getConfig('ipv4ipv4attackerhitcount', 5, options.configfile)
 
 
-
 if __name__ == '__main__':
     parser = OptionParser()
     parser.add_option(

--- a/docker/compose/docker-compose-cloudy-mozdef.yml
+++ b/docker/compose/docker-compose-cloudy-mozdef.yml
@@ -69,6 +69,8 @@ services:
     image: mozdef/mozdef_alerts
     env_file:
       - cloudy_mozdef.env
+    volumes:
+      - /opt/mozdef/docker/compose/mozdef_alerts/files/config.py:/opt/mozdef/envs/mozdef/alerts/lib/config.py
     restart: always
     command: bash -c 'source /opt/mozdef/envs/python/bin/activate && celery -A celeryconfig worker --loglevel=info --beat'
     depends_on:

--- a/docs/source/alert_development_guide.rst
+++ b/docs/source/alert_development_guide.rst
@@ -44,8 +44,9 @@ Requirements:
 
 This test should pass and you will have confirmed you have a working environment.
 
-At this point, begin development and periodically run your unit-tests locally with the following command::
+At this point, begin development and periodically run your unit-tests locally with the following commands::
 
+  make build-tests
   make run-tests TEST_CASE=tests/alerts/[YOUR ALERT TEST FILE].py
 
 

--- a/tests/alerts/test_alert_template.template
+++ b/tests/alerts/test_alert_template.template
@@ -29,6 +29,7 @@ class TEMPLATE_TEST_CLASSNAME(AlertTestSuite):
         "tags": ['hello', 'world'],
         "severity": "WARNING",
         "summary": 'My first alert!',
+        "notify_mozdefbot": False,
     }
 
     test_cases = []

--- a/tests/alerts/test_guard_duty_probe.py
+++ b/tests/alerts/test_guard_duty_probe.py
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+from positive_alert_test_case import PositiveAlertTestCase
+from negative_alert_test_case import NegativeAlertTestCase
+from alert_test_suite import AlertTestSuite
+
+
+class TestGuardDutyProbe(AlertTestSuite):
+    alert_filename = "guard_duty_probe"
+    alert_classname = "AlertGuardDutyProbe"
+
+    # This event is the default positive event that will cause the
+    # alert to trigger
+    default_event = {
+        "_type": "event",
+        "_source": {
+            "source": "guardduty",
+            "details": {
+                "sourceipaddress": "1.2.3.4",
+                "finding": {"action":
+                            {"actionType": "PORT_PROBE"}
+                            }
+            }
+        }
+    }
+
+    # This alert is the expected result from running this task
+    default_alert = {
+        "category": "bruteforce",
+        "tags": ['guardduty', 'bruteforce'],
+        "severity": "INFO",
+        "summary": 'Guard Duty Port Probe by 1.2.3.4',
+        "notify_mozdefbot": False,
+    }
+
+    test_cases = []
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test with default events and default alert expected",
+            events=AlertTestSuite.create_events(default_event, 1),
+            expected_alert=default_alert
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_source']['source'] = 'bad'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with events with incorrect category",
+            events=events,
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event['_source']['details']['sourceipaddress'] = None
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with events with non-existent sourceipaddress",
+            events=events,
+        )
+    )
+
+    for event in events:
+        event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda(
+            date_timedelta={'minutes': 21})
+        event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda(
+            date_timedelta={'minutes': 21})
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with old timestamp",
+            events=events,
+        )
+    )

--- a/tests/alerts/test_guard_duty_probe.py
+++ b/tests/alerts/test_guard_duty_probe.py
@@ -19,9 +19,11 @@ class TestGuardDutyProbe(AlertTestSuite):
             "source": "guardduty",
             "details": {
                 "sourceipaddress": "1.2.3.4",
-                "finding": {"action":
-                            {"actionType": "PORT_PROBE"}
-                            }
+                "finding": {
+                    "action": {
+                        "actionType": "PORT_PROBE"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
* Make threshold for attackers and cidr blocks configurable.
* Update CloudFormation to configure alert workers
* Add @jeffbryner changes to add guarduty basic alert for port probes
* Set Meteor ROOTURL (Closes #925)
* Add GuardDuty alerts
