### PR TITLE
deduplicating get_aws_credentials function

### DIFF
--- a/mq/common.py
+++ b/mq/common.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+
+def get_aws_credentials(region=None, access_key=None, secret_key=None, security_token=None):
+    result = {}
+    if region and region != '<add_region>':
+        result['region_name'] = region
+    if access_key and access_key != '<add_accesskey>':
+        result['aws_access_key_id'] = access_key
+    if secret_key and secret_key != '<add_secretkey>':
+        result['aws_secret_access_key'] = secret_key
+    if security_token:
+        result['security_token'] = security_token
+    return result

--- a/mq/esworker_sns_sqs.py
+++ b/mq/esworker_sns_sqs.py
@@ -24,6 +24,8 @@ from mozdef_util.utilities.toUTC import toUTC
 from mozdef_util.utilities.logger import logger, initLogger
 from mozdef_util.elasticsearch_client import ElasticsearchClient, ElasticsearchBadServer, ElasticsearchInvalidIndex, ElasticsearchException
 
+from commmon import get_aws_credentials
+
 from lib.plugins import sendEventToPlugins, registerPlugins
 from lib.sqs import connect_sqs
 
@@ -39,19 +41,6 @@ except ImportError as e:
 def esConnect():
     '''open or re-open a connection to elastic search'''
     return ElasticsearchClient((list('{0}'.format(s) for s in options.esservers)), options.esbulksize)
-
-
-def get_aws_credentials(region=None, accesskey=None, secretkey=None, security_token=None):
-    result = {}
-    if region not in ['', '<add_region>', None]:
-        result['region_name'] = region
-    if accesskey not in ['', '<add_accesskey>', None]:
-        result['aws_access_key_id'] = accesskey
-    if secretkey not in ['', '<add_secretkey>', None]:
-        result['aws_secret_access_key'] = secretkey
-    if security_token not in [None]:
-        result['security_token'] = security_token
-    return result
 
 
 class taskConsumer(object):

--- a/mq/esworker_sqs.py
+++ b/mq/esworker_sqs.py
@@ -12,7 +12,6 @@
 
 
 import json
-import os
 import sys
 import socket
 import time
@@ -30,6 +29,8 @@ from mozdef_util.utilities.is_cef import isCEF
 from mozdef_util.utilities.logger import logger, initLogger
 from mozdef_util.elasticsearch_client import ElasticsearchClient, ElasticsearchBadServer, ElasticsearchInvalidIndex, ElasticsearchException
 
+from common import get_aws_credentials
+
 from lib.plugins import sendEventToPlugins, registerPlugins
 from lib.sqs import connect_sqs
 
@@ -40,19 +41,6 @@ try:
     hasUWSGI = True
 except ImportError as e:
     hasUWSGI = False
-
-
-def get_aws_credentials(region=None, accesskey=None, secretkey=None, security_token=None):
-    result = {}
-    if region not in ['', '<add_region>', None]:
-        result['region_name'] = region
-    if accesskey not in ['', '<add_accesskey>', None]:
-        result['aws_access_key_id'] = accesskey
-    if secretkey not in ['', '<add_secretkey>', None]:
-        result['aws_secret_access_key'] = secretkey
-    if security_token not in [None]:
-        result['security_token'] = security_token
-    return result
 
 
 def keyMapping(aDict):


### PR DESCRIPTION
closes: #970 

## Changes

Moving the `get_aws_credentials` function to a central `common.py` file and updating worker files to import the new method.

