### PR TITLE
Update urllib3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,6 @@ six==1.11.0
 supervisor==3.3.1
 tzlocal==1.4
 uritemplate==0.6
-urllib3==1.22
+urllib3==1.23
 uwsgi==2.0.17.1
 virtualenv==1.11.4


### PR DESCRIPTION
This is due to:

CVE-2018-20060
More information
high severity
Vulnerable versions: < 1.23
Patched version: 1.23

urllib3 before version 1.23 does not remove the Authorization HTTP header when following a cross-origin redirect (i.e., a redirect that differs in host, port, or scheme). This can allow for credentials in the Authorization header to be exposed to unintended hosts or transmitted in cleartext.
