### PR TITLE
Update requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ pynsive==0.2.6
 pyparsing==2.1.10
 python-dateutil==2.6.1
 pytz==2017.3
-requests==2.18.4
+requests==2.20.0
 requests-futures==0.9.7
 rsa==3.1.4
 s3cmd==1.0.1


### PR DESCRIPTION
Updating because of:

CVE-2018-18074
More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0

The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.
