### PR TITLE
fixup spacing

### DIFF
--- a/meteor/public/css/dropdowns.css
+++ b/meteor/public/css/dropdowns.css
@@ -6,7 +6,7 @@
 ul.dropdown {
     position: relative;
     display: inline-block;
-    width: min-content;
+    width: max-content;
     border: 1px solid rgba(0, 0, 0, 0.2);
     border-radius: 3px;
     box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
fix css to allow for IP address without wrapping. Otherwise the pull down is placed on the next line like: 
<img width="137" alt="screen shot 2018-12-25 at 1 08 28 pm" src="https://user-images.githubusercontent.com/566889/50426578-42070500-0846-11e9-9491-7ac8185a4b79.png">
