### PR TITLE
Update configlib version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ bottle==0.12.4
 bugzilla==1.0.0
 celery==4.1.0
 cffi==1.9.1
-configlib==2.0.2
+configlib==2.0.3
 configparser==3.5.0b2
 cryptography==2.3.1
 dnspython==1.15.0


### PR DESCRIPTION
This currently fixes an issue where configlib v 2.0.2 doesn't version lock everett, so we get similar errors as:
```
Traceback (most recent call last):
  File "initial_setup.py", line 12, in <module>
    from configlib import getConfig
  File "/opt/mozdef/envs/python/lib/python2.7/site-packages/configlib/__init__.py", line 1, in <module>
    from configlib import getConfig
  File "/opt/mozdef/envs/python/lib/python2.7/site-packages/configlib/configlib.py", line 6, in <module>
    from everett.manager import ConfigIniEnv
ImportError: cannot import name ConfigIniEnv
```

Depends on https://github.com/jeffbryner/configlib/pull/8