### PR TITLE
Setup default hosted CloudFormation templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ MozDef is in production at Mozilla where we are using it to process over 300 mil
 
 ## Give MozDef a Try in AWS:
 
-[![Launch MozDef](docs/source/images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=mozdef-for-aws&templateURL=https://s3-us-west-2.amazonaws.com/mozdef.infosec.allizom.org/cf/mozdef-parent.yml)
+[![Launch MozDef](docs/source/images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=mozdef-for-aws&templateURL=https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/mozdef/cf/mozdef-parent.yml)
 
 ## Documentation:
 

--- a/cloudy_mozdef/Makefile
+++ b/cloudy_mozdef/Makefile
@@ -7,9 +7,14 @@ STACK_PARAMS_FILENAME	:= aws_parameters.json
 STACK_PARAMS	:= $(shell test -e $(STACK_PARAMS_FILENAME) && python -c 'import json,sys;f=open(sys.argv[1]);print(" ".join([",".join(["%s=\\\"%s\\\""%(k,v) for k,v in x.items()]) for x in json.load(f)]));f.close()' $(STACK_PARAMS_FILENAME))
 # MozDef uses a nested CF stack, the mozdef-parent.yml will tie all child stacks together and load them from S3
 # See also mozdef.infosec.mozilla.org bucket
-S3_BUCKET_NAME  := mozdef.infosec.allizom.org
+S3_BUCKET_NAME	:= mozdef.infosec.allizom.org
 S3_BUCKET_PATH	:= cf
 S3_BUCKET_URI	:= s3://$(S3_BUCKET_NAME)/$(S3_BUCKET_PATH)
+# Location to publish templates for public consumption
+S3_PUBLISHED_BUCKET_NAME	:= public.us-west-2.infosec.mozilla.org
+S3_PUBLISHED_BUCKET_PATH	:= mozdef/cf
+S3_PUBLISHED_BUCKET_URI	:= s3://$(S3_PUBLISHED_BUCKET_NAME)/$(S3_PUBLISHED_BUCKET_PATH)
+
 S3_STACK_URI	:= https://s3-$(AWS_REGION).amazonaws.com/$(S3_BUCKET_NAME)/$(S3_BUCKET_PATH)/
 # OIDC_CLIENT_SECRET is set in an environment variable by running "source aws_parameters.sh"
 OIDC_CLIENT_SECRET_PARAM_ARG := $(shell test -n "$(OIDC_CLIENT_SECRET)" && echo "ParameterKey=OIDCClientSecret,ParameterValue=$(OIDC_CLIENT_SECRET)")
@@ -63,4 +68,9 @@ stack-status: ## Output current CloudFormation stack status
 .PHONY: upload-templates
 upload-templates:
 	@export AWS_REGION=$(AWS_REGION)
-	aws s3 sync cloudformation/ $(S3_BUCKET_URI) --acl public-read
+	aws s3 sync cloudformation/ $(S3_BUCKET_URI) --acl public-read --exclude="*" --include="*.yml"
+
+.PHONY: upload-templates
+publish-templates:
+	@export AWS_REGION=$(AWS_REGION)
+	aws s3 sync cloudformation/ $(S3_PUBLISHED_BUCKET_URI) --exclude="*" --include="*.yml"

--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -90,9 +90,10 @@ Parameters:
     NoEcho: true
   S3TemplateLocation:
     Type: String
-    AllowedPattern: '^https?:\/\/.*\.amazonaws\.com\/.*'
+    AllowedPattern: '^https?:\/\/.*\.amazonaws\.com\/.*\/'
     ConstraintDescription: A valid amazonaws.com S3 URL
     Description: "The URL to the S3 bucket used to fetch the nested stack templates (Example: https://s3-us-west-2.amazonaws.com/example-bucket-name/cloudformation/path/)"
+    Default: https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/mozdef/cf/
 Resources:
   MozDefSecurityGroups:
     Type: AWS::CloudFormation::Stack

--- a/docs/source/cloud_deployment.rst
+++ b/docs/source/cloud_deployment.rst
@@ -7,7 +7,7 @@ Cloud based MozDef is an opinionated deployment of the MozDef services created i
 ingest cloudtrail, guardduty, and provide security services.
 
 .. image:: images/cloudformation-launch-stack.png
-   :target: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=mozdef-for-aws&templateURL=https://s3-us-west-2.amazonaws.com/mozdef.infosec.allizom.org/cf/mozdef-parent.yml
+   :target: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=mozdef-for-aws&templateURL=https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/mozdef/cf/mozdef-parent.yml
 
 
 Feedback


### PR DESCRIPTION
* Update the AWS launch button link
* Use the new public S3 buckets for hosting the CloudFormation templates (mozilla/security#21)
* Create a new make target to publish templates to this bucket