### PR TITLE
Pin yum repo keys

### DIFF
--- a/docker/compose/mongodb/Dockerfile
+++ b/docker/compose/mongodb/Dockerfile
@@ -6,6 +6,11 @@ ENV MONGO_VERSION 3.4
 
 RUN \
   echo -e "[mongodb-org-$MONGO_VERSION]\nname=MongoDB Repository\nbaseurl=https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/$MONGO_VERSION/x86_64/\ngpgcheck=1\nenabled=1\ngpgkey=https://www.mongodb.org/static/pgp/server-$MONGO_VERSION.asc" > /etc/yum.repos.d/mongodb.repo && \
+  gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
+  rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
+  rpmkeys --import https://www.mongodb.org/static/pgp/server-3.4.asc && \
+  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
   yum install -y mongodb-org && \
   yum clean all
 

--- a/docker/compose/mongodb/Dockerfile
+++ b/docker/compose/mongodb/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
   rpmkeys --import https://www.mongodb.org/static/pgp/server-3.4.asc && \
-  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
+  rpm -qi gpg-pubkey-a15703c6 | $gpg | grep 0xBC711F9BA15703C6 && \
   yum install -y mongodb-org && \
   yum clean all
 

--- a/docker/compose/mozdef_syslog/Dockerfile
+++ b/docker/compose/mozdef_syslog/Dockerfile
@@ -5,6 +5,13 @@ LABEL maintainer="mozdef@mozilla.com"
 COPY docker/compose/mozdef_syslog/files/syslog-ng.repo /etc/yum.repos.d/syslog-ng.repo
 
 RUN \
+  gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
+  rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
+  rpmkeys --import https://copr-be.cloud.fedoraproject.org/results/czanik/syslog-ng312/pubkey.gpg && \
+  rpm -qi gpg-pubkey-2b04b9af | $gpg | grep 0x1AACFE032B04B9AF && \
+  rpmkeys --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 && \
+  rpm -qi gpg-pubkey-352c64e5 | $gpg | grep 0x6A2FAEA2352C64E5 && \
   yum install -y epel-release && \
   yum install -y syslog-ng.x86_64 syslog-ng-json && \
   yum clean all

--- a/docker/compose/nginx/Dockerfile
+++ b/docker/compose/nginx/Dockerfile
@@ -3,8 +3,13 @@ FROM centos:7
 LABEL maintainer="mozdef@mozilla.com"
 
 RUN \
+  gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
+  rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
   mkdir /var/log/mozdef && \
   yum makecache fast && \
+  rpmkeys --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 && \
+  rpm -qi gpg-pubkey-352c64e5 | $gpg | grep 0x6A2FAEA2352C64E5 && \
   yum install -y epel-release && \
   yum install -y nginx && \
   yum clean all


### PR DESCRIPTION
This pins the gpg fingerprint of the yum repositories used both
to prevent the error messages and to make any packages signed by
different keys to cause builds to fail

This is instead of #1038 which had the wrong mongodb key fingerprint