### PR TITLE
Lowercase potential matching keys in mq plugins

### DIFF
--- a/mq/lib/plugins.py
+++ b/mq/lib/plugins.py
@@ -33,7 +33,9 @@ def sendEventToPlugins(anevent, metadata, pluginList):
         send = False
         if isinstance(plugin[1], list):
             try:
-                if (set(plugin[1]).intersection([e for e in dict2List(anevent)])):
+                plugin_matching_keys = set([item.lower() for item in plugin[1]])
+                event_tokens = [e for e in dict2List(anevent)]
+                if plugin_matching_keys.intersection(event_tokens):
                     send = True
             except TypeError:
                 logger.error('TypeError on set intersection for dict {0}'.format(anevent))


### PR DESCRIPTION
Since we lowercase all of the event's keys and values, I figured we should be consistent and lowercase the potential matching values from plugins.