### PR TITLE
Add generic env run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,8 @@ run-cloudy-mozdef: ## Run the MozDef containers necessary to run in AWS (`cloudy
 .PHONY: run-env-mozdef
 run-env-mozdef: ## Run the MozDef containers with a user specified env file. Run with make 'run-env-mozdef -e ENV=my.env'
 	$(shell test -f $(ENV) || touch $(ENV))
-	$(shell cp $(ENV) docker/compose/user_input.env)
-	docker-compose -f docker/compose/docker-compose-user-env.yml -p $(NAME) pull
-	docker-compose -f docker/compose/docker-compose-user-env.yml -p $(NAME) up -d
+	ENV_FILE=$(abspath $(ENV))
+	docker-compose -f docker/compose/docker-compose.yml -f docker/compose/docker-compose-user-env.yml -p $(NAME) up -d
 
 restart-cloudy-mozdef:
 	docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p $(NAME) restart

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,13 @@ run-cloudy-mozdef: ## Run the MozDef containers necessary to run in AWS (`cloudy
 	docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p $(NAME) pull
 	docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p $(NAME) up -d
 
+.PHONY: run-env-mozdef
+run-env-mozdef: ## Run the MozDef containers with a user specified env file. Run with make 'run-env-mozdef -e ENV=my.env'
+	$(shell test -f $(ENV) || touch $(ENV))
+	$(shell cp $(ENV) docker/compose/user_input.env)
+	docker-compose -f docker/compose/docker-compose-user-env.yml -p $(NAME) pull
+	docker-compose -f docker/compose/docker-compose-user-env.yml -p $(NAME) up -d
+
 restart-cloudy-mozdef:
 	docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p $(NAME) restart
 

--- a/docker/compose/docker-compose-user-env.yml
+++ b/docker/compose/docker-compose-user-env.yml
@@ -2,311 +2,54 @@
 version: '3.7'
 services:
   nginx:
-    image: mozdef/mozdef_nginx
-    build:
-      context: ../../
-      dockerfile: docker/compose/nginx/Dockerfile
-      cache_from:
-        - mozdef/mozdef_nginx
-        - mozdef_nginx:latest
-    restart: always
-    command: /usr/sbin/nginx
-    depends_on:
-      - kibana
-      - meteor
-    ports:
-      - 80:80
-      - 8080:8080
-      - 9090:9090
-      # - 8081:8081
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   mongodb:
-    image: mozdef/mozdef_mongodb
-    build:
-      context: ../../
-      dockerfile: docker/compose/mongodb/Dockerfile
-      cache_from:
-        - mozdef/mozdef_mongodb
-        - mozdef_mongodb:latest
-    restart: always
-    command: /usr/bin/mongod --smallfiles --config /etc/mongod.conf
-    volumes:
-      - mongodb:/var/lib/mongo
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   kibana:
-    image: mozdef/mozdef_kibana
-    build:
-      context: ../../
-      dockerfile: docker/compose/kibana/Dockerfile
-      cache_from:
-        - mozdef/mozdef_kibana
-        - mozdef_kibana:latest
-    restart: always
-    command: bin/kibana --elasticsearch=http://elasticsearch:9200
-    depends_on:
-      - elasticsearch
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   elasticsearch:
-    image: mozdef/mozdef_elasticsearch
-    build:
-      context: ../../
-      dockerfile: docker/compose/elasticsearch/Dockerfile
-      cache_from:
-        - mozdef/mozdef_elasticsearch
-        - mozdef_elasticsearch:latest
-    command: bin/elasticsearch
-    restart: always
-    volumes:
-      - elasticsearch:/var/lib/elasticsearch
-    # ports:
-    #   - 9200:9200
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   rabbitmq:
-    image: mozdef/mozdef_rabbitmq
-    build:
-      context: ../../
-      dockerfile: docker/compose/rabbitmq/Dockerfile
-      cache_from:
-        - mozdef/mozdef_rabbitmq
-        - mozdef_rabbitmq:latest
-    restart: always
-    command: rabbitmq-server
-    volumes:
-      - rabbitmq:/var/lib/rabbitmq
-    # ports:
-    #   - 5672:5672
-    #   - 15672:15672 # Admin interface
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   # MozDef Specific Containers
   base:
-    image: mozdef/mozdef_base
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_base/Dockerfile
-      cache_from:
-        - mozdef/mozdef_base
-        - mozdef_base:latest
-    command: bash -c 'su - mozdef -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh'
-    volumes:
-      - geolite_db:/opt/mozdef/envs/mozdef/data
     env_file:
-      - user_input.env
+      - $ENV_FILE
   bootstrap:
-    image: mozdef/mozdef_bootstrap
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_bootstrap/Dockerfile
-      cache_from:
-        - mozdef/mozdef_bootstrap
-        - mozdef_bootstrap:latest
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python initial_setup.py http://elasticsearch:9200 cron/defaultMappingTemplate.json cron/backup.conf'
-    depends_on:
-      - base
-      - elasticsearch
-    environment:
-      - ES_URL=http://localhost:9200
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   alertplugins:
-    image: mozdef/mozdef_alertplugins
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_alertplugins/Dockerfile
-      cache_from:
-        - mozdef/mozdef_alertplugins
-        - mozdef_alertplugins:latest
-    restart: always
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python alert_worker.py -c alert_worker.conf'
-    depends_on:
-      - base
-      - elasticsearch
-      - rabbitmq
-      - alerts
-      - bootstrap
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   alerts:
-    image: mozdef/mozdef_alerts
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_alerts/Dockerfile
-      cache_from:
-        - mozdef/mozdef_alerts
-        - mozdef_alerts:latest
-    restart: always
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && celery -A celeryconfig worker --loglevel=info --beat'
-    depends_on:
-      - base
-      - elasticsearch
-      - rabbitmq
-      - bootstrap
-    networks:
-      - default
     env_file:
-      - user_input.env
-  # bot:
-  #   restart: always
-  #   command: bash -c 'sleep 90 && source /opt/mozdef/envs/python/bin/activate && python mozdefbot.py -c mozdefbot.conf'
-  #   depends_on:
-  #     - base
-  #     - rabbitmq
-  #     - alerts
-  #     - bootstrap
-  #   networks:
-  #     - default
-  #   volumes:
-  #     - geolite_db:/opt/mozdef/envs/mozdef/data/
+      - $ENV_FILE
   cron:
-    image: mozdef/mozdef_cron
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_cron/Dockerfile
-      cache_from:
-        - mozdef/mozdef_cron
-        - mozdef_cron:latest
-    restart: always
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && crond -n'
-    volumes:
-      - cron:/opt/mozdef/envs/mozdef/cron
-      - geolite_db:/opt/mozdef/envs/mozdef/data/
-    depends_on:
-      - base
-      - rabbitmq
-      - elasticsearch
-      - mongodb
-      - bootstrap
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   loginput:
-    image: mozdef/mozdef_loginput
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_loginput/Dockerfile
-      cache_from:
-        - mozdef/mozdef_loginput
-        - mozdef_loginput:latest
-    restart: always
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python index.py -c index.conf'
-    depends_on:
-      - base
-      - elasticsearch
-      - rabbitmq
-      - bootstrap
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   mq_worker:
-    image: mozdef/mozdef_mq_worker
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_mq_worker/Dockerfile
-      cache_from:
-        - mozdef/mozdef_mq_worker
-        - mozdef_mq_worker:latest
-    restart: always
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python esworker_eventtask.py -c esworker_eventtask.conf'
-    depends_on:
-      - base
-      - rabbitmq
-      - elasticsearch
-      - loginput
-      - bootstrap
-    networks:
-      - default
-    volumes:
-      - geolite_db:/opt/mozdef/envs/mozdef/data/
     env_file:
-      - user_input.env
+      - $ENV_FILE
   meteor:
-    image: mozdef/mozdef_meteor
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_meteor/Dockerfile
-      cache_from:
-        - mozdef/mozdef_meteor
-        - mozdef_meteor:latest
-    restart: always
-    command: bash -c 'node bundle/main.js'
-    depends_on:
-      - mongodb
-      - rest
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   rest:
-    image: mozdef/mozdef_rest
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_rest/Dockerfile
-      cache_from:
-        - mozdef/mozdef_rest
-        - mozdef_rest:latest
-    restart: always
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python index.py -c index.conf'
-    depends_on:
-      - base
-      - elasticsearch
-      - mongodb
-      - bootstrap
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   syslog:
-    image: mozdef/mozdef_syslog
-    build:
-      context: ../../
-      dockerfile: docker/compose/mozdef_syslog/Dockerfile
-      cache_from:
-        - mozdef/mozdef_syslog
-        - mozdef_syslog:latest
-    restart: always
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/rabbitmq/5672";do sleep 1;done && /usr/sbin/syslog-ng --no-caps -F'
-    depends_on:
-      - loginput
-      - mq_worker
-    ports:
-      - 514:514/udp
-      - 514:514
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
   tester:
-    image: mozdef/mozdef_tester
-    build:
-      context: ../../
-      dockerfile: docker/compose/tester/Dockerfile
-      cache_from:
-        - mozdef/mozdef_tester
-        - mozdef_tester:latest
-    networks:
-      - default
     env_file:
-      - user_input.env
+      - $ENV_FILE
 
 volumes:
   elasticsearch:

--- a/docker/compose/docker-compose-user-env.yml
+++ b/docker/compose/docker-compose-user-env.yml
@@ -1,0 +1,319 @@
+---
+version: '3.7'
+services:
+  nginx:
+    image: mozdef/mozdef_nginx
+    build:
+      context: ../../
+      dockerfile: docker/compose/nginx/Dockerfile
+      cache_from:
+        - mozdef/mozdef_nginx
+        - mozdef_nginx:latest
+    restart: always
+    command: /usr/sbin/nginx
+    depends_on:
+      - kibana
+      - meteor
+    ports:
+      - 80:80
+      - 8080:8080
+      - 9090:9090
+      # - 8081:8081
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  mongodb:
+    image: mozdef/mozdef_mongodb
+    build:
+      context: ../../
+      dockerfile: docker/compose/mongodb/Dockerfile
+      cache_from:
+        - mozdef/mozdef_mongodb
+        - mozdef_mongodb:latest
+    restart: always
+    command: /usr/bin/mongod --smallfiles --config /etc/mongod.conf
+    volumes:
+      - mongodb:/var/lib/mongo
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  kibana:
+    image: mozdef/mozdef_kibana
+    build:
+      context: ../../
+      dockerfile: docker/compose/kibana/Dockerfile
+      cache_from:
+        - mozdef/mozdef_kibana
+        - mozdef_kibana:latest
+    restart: always
+    command: bin/kibana --elasticsearch=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  elasticsearch:
+    image: mozdef/mozdef_elasticsearch
+    build:
+      context: ../../
+      dockerfile: docker/compose/elasticsearch/Dockerfile
+      cache_from:
+        - mozdef/mozdef_elasticsearch
+        - mozdef_elasticsearch:latest
+    command: bin/elasticsearch
+    restart: always
+    volumes:
+      - elasticsearch:/var/lib/elasticsearch
+    # ports:
+    #   - 9200:9200
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  rabbitmq:
+    image: mozdef/mozdef_rabbitmq
+    build:
+      context: ../../
+      dockerfile: docker/compose/rabbitmq/Dockerfile
+      cache_from:
+        - mozdef/mozdef_rabbitmq
+        - mozdef_rabbitmq:latest
+    restart: always
+    command: rabbitmq-server
+    volumes:
+      - rabbitmq:/var/lib/rabbitmq
+    # ports:
+    #   - 5672:5672
+    #   - 15672:15672 # Admin interface
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  # MozDef Specific Containers
+  base:
+    image: mozdef/mozdef_base
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_base/Dockerfile
+      cache_from:
+        - mozdef/mozdef_base
+        - mozdef_base:latest
+    command: bash -c 'su - mozdef -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh'
+    volumes:
+      - geolite_db:/opt/mozdef/envs/mozdef/data
+    env_file:
+      - user_input.env
+  bootstrap:
+    image: mozdef/mozdef_bootstrap
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_bootstrap/Dockerfile
+      cache_from:
+        - mozdef/mozdef_bootstrap
+        - mozdef_bootstrap:latest
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python initial_setup.py http://elasticsearch:9200 cron/defaultMappingTemplate.json cron/backup.conf'
+    depends_on:
+      - base
+      - elasticsearch
+    environment:
+      - ES_URL=http://localhost:9200
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  alertplugins:
+    image: mozdef/mozdef_alertplugins
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_alertplugins/Dockerfile
+      cache_from:
+        - mozdef/mozdef_alertplugins
+        - mozdef_alertplugins:latest
+    restart: always
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python alert_worker.py -c alert_worker.conf'
+    depends_on:
+      - base
+      - elasticsearch
+      - rabbitmq
+      - alerts
+      - bootstrap
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  alerts:
+    image: mozdef/mozdef_alerts
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_alerts/Dockerfile
+      cache_from:
+        - mozdef/mozdef_alerts
+        - mozdef_alerts:latest
+    restart: always
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && celery -A celeryconfig worker --loglevel=info --beat'
+    depends_on:
+      - base
+      - elasticsearch
+      - rabbitmq
+      - bootstrap
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  # bot:
+  #   restart: always
+  #   command: bash -c 'sleep 90 && source /opt/mozdef/envs/python/bin/activate && python mozdefbot.py -c mozdefbot.conf'
+  #   depends_on:
+  #     - base
+  #     - rabbitmq
+  #     - alerts
+  #     - bootstrap
+  #   networks:
+  #     - default
+  #   volumes:
+  #     - geolite_db:/opt/mozdef/envs/mozdef/data/
+  cron:
+    image: mozdef/mozdef_cron
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_cron/Dockerfile
+      cache_from:
+        - mozdef/mozdef_cron
+        - mozdef_cron:latest
+    restart: always
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && crond -n'
+    volumes:
+      - cron:/opt/mozdef/envs/mozdef/cron
+      - geolite_db:/opt/mozdef/envs/mozdef/data/
+    depends_on:
+      - base
+      - rabbitmq
+      - elasticsearch
+      - mongodb
+      - bootstrap
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  loginput:
+    image: mozdef/mozdef_loginput
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_loginput/Dockerfile
+      cache_from:
+        - mozdef/mozdef_loginput
+        - mozdef_loginput:latest
+    restart: always
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python index.py -c index.conf'
+    depends_on:
+      - base
+      - elasticsearch
+      - rabbitmq
+      - bootstrap
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  mq_worker:
+    image: mozdef/mozdef_mq_worker
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_mq_worker/Dockerfile
+      cache_from:
+        - mozdef/mozdef_mq_worker
+        - mozdef_mq_worker:latest
+    restart: always
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python esworker_eventtask.py -c esworker_eventtask.conf'
+    depends_on:
+      - base
+      - rabbitmq
+      - elasticsearch
+      - loginput
+      - bootstrap
+    networks:
+      - default
+    volumes:
+      - geolite_db:/opt/mozdef/envs/mozdef/data/
+    env_file:
+      - user_input.env
+  meteor:
+    image: mozdef/mozdef_meteor
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_meteor/Dockerfile
+      cache_from:
+        - mozdef/mozdef_meteor
+        - mozdef_meteor:latest
+    restart: always
+    command: bash -c 'node bundle/main.js'
+    depends_on:
+      - mongodb
+      - rest
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  rest:
+    image: mozdef/mozdef_rest
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_rest/Dockerfile
+      cache_from:
+        - mozdef/mozdef_rest
+        - mozdef_rest:latest
+    restart: always
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/elasticsearch/9200";do sleep 1;done && source /opt/mozdef/envs/python/bin/activate && python index.py -c index.conf'
+    depends_on:
+      - base
+      - elasticsearch
+      - mongodb
+      - bootstrap
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  syslog:
+    image: mozdef/mozdef_syslog
+    build:
+      context: ../../
+      dockerfile: docker/compose/mozdef_syslog/Dockerfile
+      cache_from:
+        - mozdef/mozdef_syslog
+        - mozdef_syslog:latest
+    restart: always
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/rabbitmq/5672";do sleep 1;done && /usr/sbin/syslog-ng --no-caps -F'
+    depends_on:
+      - loginput
+      - mq_worker
+    ports:
+      - 514:514/udp
+      - 514:514
+    networks:
+      - default
+    env_file:
+      - user_input.env
+  tester:
+    image: mozdef/mozdef_tester
+    build:
+      context: ../../
+      dockerfile: docker/compose/tester/Dockerfile
+      cache_from:
+        - mozdef/mozdef_tester
+        - mozdef_tester:latest
+    networks:
+      - default
+    env_file:
+      - user_input.env
+
+volumes:
+  elasticsearch:
+  rabbitmq:
+  mongodb:
+  cron:
+  geolite_db:
+
+networks:
+  default:

--- a/docker/compose/docker-compose-user-env.yml
+++ b/docker/compose/docker-compose-user-env.yml
@@ -50,13 +50,3 @@ services:
   tester:
     env_file:
       - $ENV_FILE
-
-volumes:
-  elasticsearch:
-  rabbitmq:
-  mongodb:
-  cron:
-  geolite_db:
-
-networks:
-  default:


### PR DESCRIPTION
This PR adds a make target which calls a copy of the default docker compose file which has an env file enabled for all services. This env file is user supplied via the main makefile.