### PR TITLE
Assert that there are no nested lists in AlertTestCase events. Much time was spent hunting a bug related to this

### DIFF
--- a/tests/alerts/alert_test_case.py
+++ b/tests/alerts/alert_test_case.py
@@ -12,6 +12,7 @@ class AlertTestCase(object):
         # we need to copy each event so that other tests dont
         # mess with the same instance in memory
         self.events = AlertTestSuite.copy(events)
+        assert any(isinstance(i, list) for i in self.events) is False
         self.events_type = events_type
         self.expected_alert = expected_alert
         self.full_events = []

--- a/tests/alerts/alert_test_case.py
+++ b/tests/alerts/alert_test_case.py
@@ -12,7 +12,7 @@ class AlertTestCase(object):
         # we need to copy each event so that other tests dont
         # mess with the same instance in memory
         self.events = AlertTestSuite.copy(events)
-        assert any(isinstance(i, list) for i in self.events) is False
+        assert any(isinstance(i, list) for i in self.events) is False, 'Test case events contains a sublist when it should not.'
         self.events_type = events_type
         self.expected_alert = expected_alert
         self.full_events = []


### PR DESCRIPTION
In a test I was working on I mistakenly had `events.append(AlertTestSuite.create_events(x,y)`which was appending a single element that itself was a list to my `events` variable. This lead to test errors like
```
    @freeze_time("2017-01-01 01:00:00", tz_offset=0)
    def test_alert_test_case(self, test_case):
        self.verify_starting_values(test_case)
        temp_events = test_case.events
        for event in temp_events:
            temp_event = self.dict_merge(self.generate_default_event(), self.default_event)

            merged_event = self.dict_merge(temp_event, event)
>           print merged_event['_source']
E           TypeError: list indices must be integers, not str

../tests/alerts/alert_test_suite.py:152: TypeError
```
This took a lot of time to track down, so I figured a PR to shortcut the debug path was in order.