### PR TITLE
Fixup the geolite db path for slack bot

### DIFF
--- a/bot/slack/commands/ip_info.py
+++ b/bot/slack/commands/ip_info.py
@@ -8,7 +8,7 @@ from mozdef_util.utilities.is_ip import is_ip
 def ip_location(ip):
     location = ""
     try:
-        geoip_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../data/GeoLite2-City.mmdb")
+        geoip_data_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../data/GeoLite2-City.mmdb")
         geoip = GeoIP(geoip_data_dir)
         geo_dict = geoip.lookup_ip(ip)
         if geo_dict is not None:


### PR DESCRIPTION
I had made https://github.com/mozilla/MozDef/pull/1081 as a temp fix until we updated our release playbook to handle the path correctly. We've since done that, so we should restore the original path structure to the code.