### PR TITLE
Assert expected_alert is None in NegativeAlertTestCase. 

### DIFF
--- a/tests/alerts/negative_alert_test_case.py
+++ b/tests/alerts/negative_alert_test_case.py
@@ -2,4 +2,5 @@ from alert_test_case import AlertTestCase
 
 
 class NegativeAlertTestCase(AlertTestCase):
+    assert self.expected_alert is None, "NegativeAlertTestCase is used to test cases where an alert does not occur. Therefore expected_alert should be None."
     expected_test_result = False

--- a/tests/alerts/negative_alert_test_case.py
+++ b/tests/alerts/negative_alert_test_case.py
@@ -2,5 +2,5 @@ from alert_test_case import AlertTestCase
 
 
 class NegativeAlertTestCase(AlertTestCase):
-    assert self.expected_alert is None, "NegativeAlertTestCase is used to test cases where an alert does not occur. Therefore expected_alert should be None."
+    assert expected_alert is None, "NegativeAlertTestCase is used to test cases where an alert does not occur. Therefore expected_alert should be None."
     expected_test_result = False


### PR DESCRIPTION
Unless I misunderstand the NegativeAlertTestCase there should never be a case where an alert is created. Having the negative case take an expected alert is pretty counter intuitive when no alert should ever be created.