### PR TITLE
Fix duplicate alert generic loader

### DIFF
--- a/alerts/generic_alert_loader.py
+++ b/alerts/generic_alert_loader.py
@@ -9,8 +9,9 @@
 
 from lib.alerttask import AlertTask
 from mozdef_util.query_models import SearchQuery, TermMatch, QueryStringMatch
+from mozdef_util.utilities.dot_dict import DotDict
+from mozdef_util.utilities.logger import logger
 import hjson
-import logging
 import sys
 import traceback
 import glob
@@ -54,23 +55,6 @@ from os.path import basename
         'alert_url': 'https://mozilla.org'
     }
 '''
-
-
-logger = logging.getLogger()
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-
-
-class DotDict(dict):
-    '''dict.item notation for dict()'s'''
-    __getattr__ = dict.__getitem__
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
-
-    def __init__(self, dct):
-        for key, value in dct.items():
-            if hasattr(value, 'keys'):
-                value = DotDict(value)
-            self[key] = value
 
 
 class AlertGenericLoader(AlertTask):

--- a/alerts/generic_alert_loader.py
+++ b/alerts/generic_alert_loader.py
@@ -15,6 +15,7 @@ import sys
 import traceback
 import glob
 import os
+from os.path import basename
 
 # Minimum data needed for an alert (this is an example alert json)
 '''
@@ -103,11 +104,16 @@ class AlertGenericLoader(AlertTask):
                 try:
                     cfg = DotDict(hjson.load(fd))
                     self.validate_alert(cfg)
+                    # We set the alert name to the filename (excluding .json)
+                    alert_name = basename(f).replace('.json', '')
+                    cfg['custom_alert_name'] = alert_name
                     self.configs.append(cfg)
                 except Exception:
                     logger.error("Loading rule file {} failed".format(f))
 
     def process_alert(self, alert_config):
+        # Set instance variable to populate event attributes about an alert
+        self.custom_alert_name = "{0}:{1}".format(self.classname(), alert_config['custom_alert_name'])
         search_query = SearchQuery(minutes=int(alert_config.time_window))
         terms = []
         for i in alert_config.filters:

--- a/alerts/lib/alerttask.py
+++ b/alerts/lib/alerttask.py
@@ -453,6 +453,8 @@ class AlertTask(Task):
                 event['_source']['alert_names'].append(self.determine_alert_classname())
 
                 self.es.save_event(index=event['_index'], doc_type=event['_type'], body=event['_source'], doc_id=event['_id'])
+            # We refresh here to ensure our changes to the events will show up for the next search query results
+            self.es.refresh(event['_index'])
         except Exception as e:
             self.log.error('Error while updating events in ES: {0}'.format(e))
 

--- a/alerts/lib/alerttask.py
+++ b/alerts/lib/alerttask.py
@@ -242,11 +242,19 @@ class AlertTask(Task):
 
         """
         # Don't fire on already alerted events
-        duplicate_matcher = TermMatch('alert_names', self.classname())
+        duplicate_matcher = TermMatch('alert_names', self.determine_alert_classname())
         if duplicate_matcher not in query.must_not:
             query.add_must_not(duplicate_matcher)
 
         self.main_query = query
+
+    def determine_alert_classname(self):
+        alert_name = self.classname()
+        # Allow alerts like the generic alerts (one python alert but represents many 'alerts')
+        # can customize the alert name
+        if hasattr(self, 'custom_alert_name'):
+            alert_name = self.custom_alert_name
+        return alert_name
 
     def executeSearchEventsSimple(self):
         """
@@ -442,7 +450,7 @@ class AlertTask(Task):
 
                 if 'alert_names' not in event['_source']:
                     event['_source']['alert_names'] = []
-                event['_source']['alert_names'].append(self.classname())
+                event['_source']['alert_names'].append(self.determine_alert_classname())
 
                 self.es.save_event(index=event['_index'], doc_type=event['_type'], body=event['_source'], doc_id=event['_id'])
         except Exception as e:

--- a/docker/compose/mozdef_bootstrap/files/initial_setup.py
+++ b/docker/compose/mozdef_bootstrap/files/initial_setup.py
@@ -133,7 +133,7 @@ if len(results['hits']) == 0:
             client.save_object(body=mapping_data, index='.kibana', doc_type='index-pattern', doc_id=mapping_data['title'])
 
     # Assign default index to 'events'
-    client.flush('.kibana')
+    client.refresh('.kibana')
     default_mapping_data = {
         "defaultIndex": 'events'
     }

--- a/mozdef_util/mozdef_util/elasticsearch_client.py
+++ b/mozdef_util/mozdef_util/elasticsearch_client.py
@@ -88,6 +88,9 @@ class ElasticsearchClient():
     def flush(self, index_name):
         self.es_connection.indices.flush(index=index_name)
 
+    def refresh(self, index_name):
+        self.es_connection.indices.refresh(index=index_name)
+
     def search(self, search_query, indices, size, request_timeout):
         results = []
         try:

--- a/mozdef_util/mozdef_util/elasticsearch_client.py
+++ b/mozdef_util/mozdef_util/elasticsearch_client.py
@@ -85,9 +85,6 @@ class ElasticsearchClient():
     def get_alias(self, alias_name):
         return self.es_connection.indices.get_alias(index='*', name=alias_name).keys()
 
-    def flush(self, index_name):
-        self.es_connection.indices.flush(index=index_name)
-
     def refresh(self, index_name):
         self.es_connection.indices.refresh(index=index_name)
 

--- a/tests/alerts/alert_test_suite.py
+++ b/tests/alerts/alert_test_suite.py
@@ -146,7 +146,7 @@ class AlertTestSuite(UnitTestSuite):
             test_case.full_events.append(merged_event)
             self.populate_test_event(merged_event['_source'])
 
-        self.flush('events')
+        self.refresh('events')
 
         with mock.patch("socket.gethostbyaddr", side_effect=mock_add_hostname_to_ip):
             alert_task = test_case.run(alert_filename=self.alert_filename, alert_classname=self.alert_classname)
@@ -218,8 +218,8 @@ class AlertTestSuite(UnitTestSuite):
         assert alert_task.classname() == self.alert_classname, 'Alert classname did not match expected name'
         if test_case.expected_test_result is True:
             assert len(alert_task.alert_ids) is not 0, 'Alert did not fire as expected'
-            self.flush('alerts')
-            self.flush('events')
+            self.refresh('alerts')
+            self.refresh('events')
             for alert_id in alert_task.alert_ids:
                 found_alert = self.es_client.get_alert_by_id(alert_id)
                 self.verify_expected_alert(found_alert, test_case)

--- a/tests/mozdef_util/query_models/query_test_suite.py
+++ b/tests/mozdef_util/query_models/query_test_suite.py
@@ -32,7 +32,7 @@ class QueryTestSuite(UnitTestSuite):
                     self.setup_elasticsearch()
 
                 self.populate_test_object(event)
-                self.flush(self.event_index_name)
+                self.refresh(self.event_index_name)
 
                 # Testing must
                 search_query = SearchQuery()

--- a/tests/mozdef_util/query_models/test_aggregation.py
+++ b/tests/mozdef_util/query_models/test_aggregation.py
@@ -24,7 +24,7 @@ class TestAggregation(UnitTestSuite):
         ]
         for event in events:
             self.populate_test_object(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery()
         search_query.add_must(TermMatch('test', 'value'))
@@ -56,7 +56,7 @@ class TestAggregation(UnitTestSuite):
         ]
         for event in events:
             self.populate_test_object(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery()
         search_query.add_must(TermMatch('test', 'value'))
@@ -87,7 +87,7 @@ class TestAggregation(UnitTestSuite):
         ]
         for event in events:
             self.populate_test_object(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery()
         search_query.add_must(TermMatch('test', 'value'))
@@ -125,7 +125,7 @@ class TestAggregation(UnitTestSuite):
         ]
         for event in events:
             self.populate_test_object(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery()
         search_query.add_must(TermMatch('test', 'value'))
@@ -157,7 +157,7 @@ class TestAggregation(UnitTestSuite):
 
         for event in events:
             self.populate_test_object(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery()
         search_query.add_must(TermMatch('test', 'value'))
@@ -183,7 +183,7 @@ class TestAggregation(UnitTestSuite):
         ]
         for event in events:
             self.populate_test_object(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery()
         search_query.add_must(TermMatch('test', 'value'))
@@ -198,7 +198,7 @@ class TestAggregation(UnitTestSuite):
         for num in range(0, 100):
             event = {'keyname': 'value' + str(num)}
             self.populate_test_object(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery()
         search_query.add_must(ExistsMatch('keyname'))
@@ -210,7 +210,7 @@ class TestAggregation(UnitTestSuite):
         for num in range(0, 100):
             event = {'keyname': 'value' + str(num)}
             self.populate_test_object(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery()
         search_query.add_must(ExistsMatch('keyname'))

--- a/tests/mozdef_util/query_models/test_search_query.py
+++ b/tests/mozdef_util/query_models/test_search_query.py
@@ -138,7 +138,7 @@ class TestExecute(SearchQueryUnitTest):
             }
         )
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert results.keys() == ['hits', 'meta', 'aggregations']
@@ -202,7 +202,7 @@ class TestExecute(SearchQueryUnitTest):
         event['_source']['utctimestamp'] = event['_source']['utctimestamp']()
         event['_source']['receivedtimestamp'] = event['_source']['receivedtimestamp']()
         self.populate_test_event(event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         search_query = SearchQuery(minutes=10)
 
@@ -218,7 +218,7 @@ class TestExecute(SearchQueryUnitTest):
 
         self.populate_example_event()
         self.populate_example_event()
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert results.keys() == ['hits', 'meta', 'aggregations']
@@ -267,7 +267,7 @@ class TestExecute(SearchQueryUnitTest):
         assert query.date_timedelta == {}
 
         self.populate_example_event()
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
 
@@ -318,7 +318,7 @@ class TestExecute(SearchQueryUnitTest):
         not_old_event['receivedtimestamp'] = UnitTestSuite.subtract_from_timestamp({'seconds': 9})
         self.populate_test_event(not_old_event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert len(results['hits']) == 2
@@ -346,7 +346,7 @@ class TestExecute(SearchQueryUnitTest):
         not_old_event['receivedtimestamp'] = UnitTestSuite.subtract_from_timestamp({'minutes': 9})
         self.populate_test_event(not_old_event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert len(results['hits']) == 2
@@ -374,7 +374,7 @@ class TestExecute(SearchQueryUnitTest):
         not_old_event['receivedtimestamp'] = UnitTestSuite.subtract_from_timestamp({'hours': 9})
         self.populate_test_event(not_old_event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert len(results['hits']) == 2
@@ -402,7 +402,7 @@ class TestExecute(SearchQueryUnitTest):
         not_old_event['receivedtimestamp'] = UnitTestSuite.subtract_from_timestamp({'days': 9})
         self.populate_test_event(not_old_event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert len(results['hits']) == 2
@@ -430,7 +430,7 @@ class TestExecute(SearchQueryUnitTest):
         not_old_event['receivedtimestamp'] = UnitTestSuite.subtract_from_timestamp({'days': 9})
         self.populate_test_event(not_old_event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert len(results['hits']) == 3
@@ -449,7 +449,7 @@ class TestExecute(SearchQueryUnitTest):
         }
 
         self.populate_test_object(default_event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert len(results['hits']) == 0
@@ -467,7 +467,7 @@ class TestExecute(SearchQueryUnitTest):
     def test_execute_with_size(self):
         for num in range(0, 30):
             self.populate_example_event()
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         query = SearchQuery()
         query.add_must(ExistsMatch('summary'))
         results = query.execute(self.es_client, size=12)
@@ -476,7 +476,7 @@ class TestExecute(SearchQueryUnitTest):
     def test_execute_without_size(self):
         for num in range(0, 1200):
             self.populate_example_event()
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         query = SearchQuery()
         query.add_must(ExistsMatch('summary'))
         results = query.execute(self.es_client)
@@ -484,7 +484,7 @@ class TestExecute(SearchQueryUnitTest):
 
     def test_execute_with_should(self):
         self.populate_example_event()
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         self.query.add_should(ExistsMatch('summary'))
         self.query.add_should(ExistsMatch('nonexistentfield'))
         results = self.query.execute(self.es_client)
@@ -514,7 +514,7 @@ class TestExecute(SearchQueryUnitTest):
         not_old_event['utctimestamp'] = UnitTestSuite.subtract_from_timestamp({'seconds': 9})
         self.populate_test_event(not_old_event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert len(results['hits']) == 2
@@ -560,7 +560,7 @@ class TestExecute(SearchQueryUnitTest):
         modified_utc_timestamp_event['utctimestamp'] = UnitTestSuite.subtract_from_timestamp({'seconds': 9})
         self.populate_test_event(modified_utc_timestamp_event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         results = query.execute(self.es_client)
         assert len(results['hits']) == 5

--- a/tests/mozdef_util/test_bulk_queue.py
+++ b/tests/mozdef_util/test_bulk_queue.py
@@ -15,7 +15,7 @@ class BulkQueueTest(UnitTestSuite):
         super(BulkQueueTest, self).setup()
 
     def num_objects_saved(self):
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         search_query = SearchQuery()
         search_query.add_must(ExistsMatch('keyname'))
         results = search_query.execute(self.es_client)

--- a/tests/mozdef_util/test_elasticsearch_client.py
+++ b/tests/mozdef_util/test_elasticsearch_client.py
@@ -26,7 +26,7 @@ class ElasticsearchClientTest(UnitTestSuite):
         self.es_client = ElasticsearchClient(self.options.esservers, bulk_refresh_time=3)
 
     def get_num_events(self):
-        self.flush('events')
+        self.refresh('events')
         search_query = SearchQuery()
         search_query.add_must(TermMatch('_type', 'event'))
         search_query.add_aggregation(Aggregation('_type'))
@@ -95,7 +95,7 @@ class TestWriteWithRead(ElasticsearchClientTest):
             'utctimestamp': '2016-08-19T16:40:57.851092+00:00'
         }
         self.saved_alert = self.es_client.save_alert(body=self.alert)
-        self.flush('alerts')
+        self.refresh('alerts')
 
     def test_saved_type(self):
         assert self.saved_alert['_type'] == 'alert'
@@ -145,7 +145,7 @@ class TestSimpleWrites(ElasticsearchClientTest):
             self.es_client.save_event(body=event)
 
         assert mock_class.request_counts == 100
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         num_events = self.get_num_events()
         assert num_events == 100
 
@@ -153,7 +153,7 @@ class TestSimpleWrites(ElasticsearchClientTest):
         event = json.dumps({"key": "example value for string of json test"})
         self.es_client.save_event(body=event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         num_events = self.get_num_events()
         assert num_events == 1
 
@@ -170,7 +170,7 @@ class TestSimpleWrites(ElasticsearchClientTest):
         event = json.dumps({"key.othername": "example value for string of json test"})
         self.es_client.save_event(body=event)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         num_events = self.get_num_events()
         assert num_events == 1
 
@@ -187,7 +187,7 @@ class TestSimpleWrites(ElasticsearchClientTest):
         query = SearchQuery()
         default_event = {}
         self.populate_test_event(default_event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         query.add_must(ExistsMatch('summary'))
         results = query.execute(self.es_client)
@@ -222,7 +222,7 @@ class TestSimpleWrites(ElasticsearchClientTest):
             }
         }
         self.populate_test_event(default_event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         query.add_must(ExistsMatch('summary'))
         results = query.execute(self.es_client)
@@ -244,7 +244,7 @@ class TestSimpleWrites(ElasticsearchClientTest):
             }
         }
         self.populate_test_event(default_event)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         query.add_must(ExistsMatch('summary'))
         results = query.execute(self.es_client)
@@ -278,7 +278,7 @@ class TestBulkWrites(BulkTest):
         for event in events:
             self.es_client.save_event(body=event, bulk=True)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         time.sleep(1)
 
         # We encountered a weird bug in travis
@@ -302,21 +302,21 @@ class TestBulkWritesWithMoreThanThreshold(BulkTest):
         for event in events:
             self.es_client.save_object(index='events', doc_type='event', body=event, bulk=True)
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
 
         # We encountered a weird bug in travis
         # that would sometimes cause the number
         # of requests sent to ES to fluctuate.
         # As a result, we're checking within 5 requests
         # from 20, to verify we are still using bulk
-        non_flushed_request_count = self.mock_class.request_counts
+        non_refreshed_request_count = self.mock_class.request_counts
         assert self.mock_class.request_counts <= 25 and self.mock_class.request_counts >= 15
         assert self.get_num_events() == 1900
         time.sleep(5)
         # All we want to check here is that during the sleep
         # we purged the queue and sent the remaining events to ES
-        assert self.mock_class.request_counts > non_flushed_request_count
-        self.flush(self.event_index_name)
+        assert self.mock_class.request_counts > non_refreshed_request_count
+        self.refresh(self.event_index_name)
         assert self.get_num_events() == 1995
 
 
@@ -333,7 +333,7 @@ class TestBulkWritesWithLessThanThreshold(BulkTest):
 
         assert self.get_num_events() == 0
 
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         time.sleep(5)
         assert self.get_num_events() == 6
 
@@ -356,7 +356,7 @@ class TestWriteWithIDExists(ElasticsearchClientTest):
         event['new_key'] = 'updated_value'
         saved_event = self.es_client.save_event(body=event, doc_id=event_id)
         assert saved_event['_id'] == event_id
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         self.es_client.get_event_by_id(event_id)
 
 
@@ -497,6 +497,6 @@ class TestBulkInvalidFormatProblem(BulkTest):
 
         self.es_client.save_object(index='events', doc_type='event', body=event, bulk=True)
         self.es_client.save_object(index='events', doc_type='event', body=malformed_event, bulk=True)
-        self.flush(self.event_index_name)
+        self.refresh(self.event_index_name)
         time.sleep(5)
         assert self.get_num_events() == 1

--- a/tests/mq/test_esworker_sns_sqs.py
+++ b/tests/mq/test_esworker_sns_sqs.py
@@ -36,7 +36,7 @@ class TestEsworkerSNSSQS(UnitTestSuite):
         self.consumer = taskConsumer(mq_conn, task_queue, es_connection, options)
 
     def search_and_verify_event(self, expected_event):
-        self.flush('events')
+        self.refresh('events')
         search_query = SearchQuery(minutes=5)
         search_query.add_must(ExistsMatch('tags'))
         results = search_query.execute(self.es_client)

--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -49,7 +49,7 @@ class TestKibanaDashboardsRoute(RestTestSuite):
         json_dashboard_location = os.path.join(os.path.dirname(__file__), "ssh_dashboard.json")
         self.es_client.save_dashboard(json_dashboard_location, "Example SSH Dashboard")
         self.es_client.save_dashboard(json_dashboard_location, "Example FTP Dashboard")
-        self.flush('.kibana')
+        self.refresh('.kibana')
 
     def test_route_endpoints(self):
         for route in self.routes:
@@ -237,7 +237,7 @@ class TestLoginCountsRoute(RestTestSuite):
             }
             self.populate_test_event(event)
 
-        self.flush('events')
+        self.refresh('events')
 
     def test_route_endpoints(self):
         for route in self.routes:

--- a/tests/unit_test_suite.py
+++ b/tests/unit_test_suite.py
@@ -67,8 +67,8 @@ class UnitTestSuite(object):
         self.es_client.delete_index(self.alert_index_name, True)
         self.es_client.delete_index('alerts', True)
 
-    def flush(self, index_name):
-        self.es_client.flush(index_name)
+    def refresh(self, index_name):
+        self.es_client.refresh(index_name)
 
     def random_ip(self):
         return str(random.randint(1, 255)) + "." + str(random.randint(1, 255)) + "." + str(random.randint(1, 255)) + "." + str(random.randint(1, 255))


### PR DESCRIPTION
This fixes the problem where multiple generic alerts could not alert on the same event. Since we are modifying and updating the event (with the alerts that triggered as a result of it), we need to make sure we "refresh" after this action.