### PR TITLE
Syslog container wait 30 seconds to boot up

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -267,7 +267,7 @@ services:
         - mozdef/mozdef_syslog
         - mozdef_syslog:latest
     restart: always
-    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/rabbitmq/5672";do sleep 1;done && /usr/sbin/syslog-ng --no-caps -F'
+    command: bash -c 'while ! timeout 1 bash -c "echo > /dev/tcp/rabbitmq/5672";do sleep 1;done && sleep 30 && /usr/sbin/syslog-ng --no-caps -F'
     depends_on:
       - loginput
     ports:


### PR DESCRIPTION
The syslog container needs to be the last container to run, so even though we're waiting for rabbitmq to start up, we also want to sleep so we ensure we're the last one.