### PR TITLE
Revert "Re-enable node tls reject check in meteor"

### DIFF
--- a/meteor/server/mozdef.js
+++ b/meteor/server/mozdef.js
@@ -11,6 +11,8 @@ import '/imports/models.js';
 if (Meteor.isServer) {
 
     Meteor.startup(function () {
+        // Since we only connect to localhost or to ourselves, adding a hack to bypass cert validation
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
         // We don't use websockets, turn 'em off to make for a faster startup
         process.env.DISABLE_WEBSOCKETS = "1";
         console.log("MozDef starting")


### PR DESCRIPTION
Reverts mozilla/MozDef#1104 - removing this line prevents restapi from being able to load plugins because it listens on localhost only, thus we are reverting to keep functionality.