### PR TITLE
Resolving issues with sshd events not parsing correctly.

### DIFF
--- a/mq/esworker_sns_sqs.py
+++ b/mq/esworker_sns_sqs.py
@@ -121,7 +121,7 @@ class taskConsumer(object):
                             elif inside_message_key in ('type', 'category'):
                                 event['category'] = inside_message_value
                             elif inside_message_key in ('summary','payload', 'message'):
-                                event['summary'] = inside_message_value
+                                event['summary'] = inside_message_value.lstrip()
                             elif inside_message_key in ('source'):
                                 event['source'] = inside_message_value
                             elif inside_message_key in ('fields', 'details'):

--- a/mq/plugins/parse_sshd.py
+++ b/mq/plugins/parse_sshd.py
@@ -10,8 +10,8 @@ class message(object):
 
     def __init__(self):
         '''
-        takes an incoming sshd message
-        and sets the doc_type
+        takes an incoming sshd message and
+        parses sshd details into fields
         '''
 
         self.registration = ['sshd']
@@ -23,35 +23,51 @@ class message(object):
         self.session_opened_regex = re.compile('^pam_unix\(sshd\:session\)\: session (opened|closed) for user (?P<username>[a-zA-Z0-9\@._-]+)(?: by \(uid\=\d*\))?$')
         self.postponed_regex = re.compile('^Postponed (?P<authmethod>\w+) for (?P<username>[a-zA-Z0-9\@._-]+) from (?P<sourceipaddress>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) port (?P<sourceport>\d{1,5}) ssh2(?: \[preauth\])?$')
         self.starting_session_regex = re.compile('^Starting session: (?P<sessiontype>\w+)(?: on )?(?P<device>pts/0)? for (?P<username>[a-zA-Z0-9\@._-]+) from (?P<sourceipaddress>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) port (?P<sourceport>\d{1,5})$')
+        self.unauthorized_user_regex = re.compile('^Invalid user (?P<username>[a-zA-Z0-9\@._-]+) from (?P<sourceipaddress>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})?$')
+        self.userauth_request_regex = re.compile('^input_userauth_request: invalid user (?P<username>[a-zA-Z0-9\@._-]+) \[preauth\]')
+        self.disconnect_regex = re.compile('^Received disconnect from (?P<sourceipaddress>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}): (?P<sourceport>\d{1,5}): (|Bye Bye|Normal Shutdown, Thank you for playing) \[preauth\]')
 
-        if 'details' in message:
-            if 'program' in message['details'] and message['details']['program'] == 'sshd':
-                    msg_unparsed = message['summary']
-                    if msg_unparsed.startswith('Accepted'):
-                        accepted_search = re.search(self.accepted_regex, msg_unparsed)
-                        if accepted_search:
-                            message['details']['authstatus'] = accepted_search.group('authstatus')
-                            message['details']['authmethod'] = accepted_search.group('authmethod')
-                            message['details']['username'] = accepted_search.group('username')
-                            message['details']['sourceipaddress'] = accepted_search.group('sourceipaddress')
-                            message['details']['sourceport'] = accepted_search.group('sourceport')
-                            message['details']['rsakeyfingerprint'] = accepted_search.group('rsakeyfingerprint')
-                    if msg_unparsed.startswith('pam_unix'):
-                        session_opened_search = re.search(self.session_opened_regex, msg_unparsed)
-                        if session_opened_search:
-                            message['details']['username'] = session_opened_search.group('username')
-                    if msg_unparsed.startswith('Postponed'):
-                        postponed_search = re.search(self.postponed_regex, msg_unparsed)
-                        if postponed_search:
-                            message['details']['username'] = postponed_search.group('username')
-                            message['details']['authmethod'] = postponed_search.group('authmethod')
-                    if msg_unparsed.startswith('Starting session'):
-                        starting_session_search = re.search(self.starting_session_regex, msg_unparsed)
-                        if starting_session_search:
-                            message['details']['sessiontype'] = starting_session_search.group('sessiontype')
-                            message['details']['username'] = starting_session_search.group('username')
-                            message['details']['sourceipaddress'] = starting_session_search.group('sourceipaddress')
-                            message['details']['sourceport'] = starting_session_search.group('sourceport')
-                            message['details']['device'] = starting_session_search.group('device')
+        if 'processname' in message and message['processname'] == 'sshd':
+            msg_unparsed = message['summary']
+            if msg_unparsed.startswith('Accepted'):
+                accepted_search = re.search(self.accepted_regex, msg_unparsed)
+                if accepted_search:
+                    message['details']['authstatus'] = accepted_search.group('authstatus')
+                    message['details']['authmethod'] = accepted_search.group('authmethod')
+                    message['details']['username'] = accepted_search.group('username')
+                    message['details']['sourceipaddress'] = accepted_search.group('sourceipaddress')
+                    message['details']['sourceport'] = accepted_search.group('sourceport')
+                    message['details']['rsakeyfingerprint'] = accepted_search.group('rsakeyfingerprint')
+            if msg_unparsed.startswith('pam_unix'):
+                session_opened_search = re.search(self.session_opened_regex, msg_unparsed)
+                if session_opened_search:
+                    message['details']['username'] = session_opened_search.group('username')
+            if msg_unparsed.startswith('Postponed'):
+                postponed_search = re.search(self.postponed_regex, msg_unparsed)
+                if postponed_search:
+                    message['details']['username'] = postponed_search.group('username')
+                    message['details']['authmethod'] = postponed_search.group('authmethod')
+            if msg_unparsed.startswith('Starting session'):
+                starting_session_search = re.search(self.starting_session_regex, msg_unparsed)
+                if starting_session_search:
+                    message['details']['sessiontype'] = starting_session_search.group('sessiontype')
+                    message['details']['username'] = starting_session_search.group('username')
+                    message['details']['sourceipaddress'] = starting_session_search.group('sourceipaddress')
+                    message['details']['sourceport'] = starting_session_search.group('sourceport')
+                    message['details']['device'] = starting_session_search.group('device')
+            if msg_unparsed.startswith('Invalid user'):
+                starting_session_search = re.search(self.unauthorized_user_regex, msg_unparsed)
+                if starting_session_search:
+                    message['details']['username'] = starting_session_search.group('username')
+                    message['details']['sourceipaddress'] = starting_session_search.group('sourceipaddress')
+            if msg_unparsed.startswith('input_userauth_request'):
+                starting_session_search = re.search(self.userauth_request_regex, msg_unparsed)
+                if starting_session_search:
+                    message['details']['username'] = starting_session_search.group('username')
+            if msg_unparsed.startswith('Received disconnect from'):
+                starting_session_search = re.search(self.disconnect_regex, msg_unparsed)
+                if starting_session_search:
+                    message['details']['sourceipaddress'] = starting_session_search.group('sourceipaddress')
+                    message['details']['sourceport'] = starting_session_search.group('sourceport')
 
         return (message, metadata)

--- a/tests/mq/plugins/test_parse_sshd.py
+++ b/tests/mq/plugins/test_parse_sshd.py
@@ -28,6 +28,7 @@ accept_message['details']['sourceipv4address'] = '10.22.74.208'
 accept_message['details']['hostname'] = 'mysuperhost.somewhere.com'
 accept_message['details']['program'] = 'sshd'
 accept_message['details']['sourceipaddress'] = '10.22.74.208'
+accept_message['details']['sourceport'] = '37486'
 
 
 # Short username, RSA fpr present
@@ -211,7 +212,7 @@ class TestSSHDPostponedMessageV3():
 
         self.msgobj = message()
         self.msg = copy.deepcopy(accept_message)
-        self.msg['summary'] = 'Postponed publickey for user1@somewhere.com from 10.22.75.209 port 37486 ssh2 [preauth]'
+        self.msg['summary'] = 'Postponed publickey for user1@somewhere.com from 10.22.74.208 port 37486 ssh2 [preauth]'
 
     def test_onMessage(self):
         metadata = {}
@@ -268,3 +269,102 @@ class TestSSHDStartingSessionV2():
         assert retmessage['details']['sourceipaddress'] == '10.22.252.6'
         assert retmessage['details']['sourceport'] == '59983'
         assert retmessage['details']['device'] == 'pts/0'
+
+
+# Invalid User - complex username
+class TestSSHDUnauthorizedUserV1():
+    def setup(self):
+
+        self.msgobj = message()
+        self.msg = copy.deepcopy(accept_message)
+        self.msg['summary'] = 'Invalid user user@loftydreams.com from 10.22.75.209'
+
+    def test_onMessage(self):
+        metadata = {}
+        metadata['doc_type'] = 'event'
+
+        (retmessage, retmeta) = self.msgobj.onMessage(self.msg, metadata)
+
+        assert retmessage is not None
+        assert retmeta is not None
+        assert retmessage['details']['username'] == 'user@loftydreams.com'
+        assert retmessage['details']['sourceipaddress'] == '10.22.75.209'
+
+
+# Input Userauth Request
+class TestSSHDUnauthorizedUsertV2():
+    def setup(self):
+
+        self.msgobj = message()
+        self.msg = copy.deepcopy(accept_message)
+        self.msg['summary'] = 'input_userauth_request: invalid user user1 [preauth]'
+
+    def test_onMessage(self):
+        metadata = {}
+        metadata['doc_type'] = 'event'
+
+        (retmessage, retmeta) = self.msgobj.onMessage(self.msg, metadata)
+
+        assert retmessage is not None
+        assert retmeta is not None
+        assert retmessage['details']['username'] == 'user1'
+
+
+# SSH Disconnect - Bye Bye
+class TestSSHDReceivedDisconnectV1():
+    def setup(self):
+
+        self.msgobj = message()
+        self.msg = copy.deepcopy(accept_message)
+        self.msg['summary'] = 'Received disconnect from 10.22.75.209: 2103: Bye Bye [preauth]'
+
+    def test_onMessage(self):
+        metadata = {}
+        metadata['doc_type'] = 'event'
+
+        (retmessage, retmeta) = self.msgobj.onMessage(self.msg, metadata)
+
+        assert retmessage is not None
+        assert retmeta is not None
+        assert retmessage['details']['sourceipaddress'] == '10.22.75.209'
+        assert retmessage['details']['sourceport'] == '2103'
+
+
+# SSH Disconnect - normal shutdown
+class TestSSHDReceivedDisconnectV2():
+    def setup(self):
+
+        self.msgobj = message()
+        self.msg = copy.deepcopy(accept_message)
+        self.msg['summary'] = 'Received disconnect from 10.22.75.209: 2103: Normal Shutdown, Thank you for playing [preauth]'
+
+    def test_onMessage(self):
+        metadata = {}
+        metadata['doc_type'] = 'event'
+
+        (retmessage, retmeta) = self.msgobj.onMessage(self.msg, metadata)
+
+        assert retmessage is not None
+        assert retmeta is not None
+        assert retmessage['details']['sourceipaddress'] == '10.22.75.209'
+        assert retmessage['details']['sourceport'] == '2103'
+
+
+# SSH Disconnect
+class TestSSHDReceivedDisconnectV3():
+    def setup(self):
+
+        self.msgobj = message()
+        self.msg = copy.deepcopy(accept_message)
+        self.msg['summary'] = 'Received disconnect from 10.22.75.209: 2103:  [preauth]'
+
+    def test_onMessage(self):
+        metadata = {}
+        metadata['doc_type'] = 'event'
+
+        (retmessage, retmeta) = self.msgobj.onMessage(self.msg, metadata)
+
+        assert retmessage is not None
+        assert retmeta is not None
+        assert retmessage['details']['sourceipaddress'] == '10.22.75.209'
+        assert retmessage['details']['sourceport'] == '2103'


### PR DESCRIPTION
Strips leading whitespace from summary field.
Parses sshd events based on processname which is built by MQ worker first, as I found that not all events have a details.program. Rather than duplicate fields of the same data, I determined it was better to use the field present across all events.