### PR TITLE
Change SSH security group allowed CIDR to user definable

### DIFF
--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -14,6 +14,7 @@ Metadata:
       - InstanceType
       - KeyName
       - AMIImageId
+      - SSHIngressCIDR
     - Label:
         default: Certificate
       Parameters:
@@ -39,6 +40,8 @@ Metadata:
         default: EC2 SSH Key Name
       AMIImageId:
         default: EC2 AMI Image ID
+      SSHIngressCIDR:
+        default: Inbound SSH allowed IP address CIDR
       DomainName:
         default: FQDN to host MozDef at
       ACMCertArn:
@@ -69,6 +72,11 @@ Parameters:
     Type: AWS::EC2::Image::Id
     Description: The AMI Image ID to use of the EC2 instance
     Default: ami-073434079b0366251
+  SSHIngressCIDR:
+    Type: String
+    AllowedPattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$'
+    ConstraintDescription: A valid CIDR (e.g. 203.0.113.0/24)
+    Description: The CIDR of IP addresses from which to allow inbound SSH connections
   DomainName:
     Type: String
     Description: The fully qualified DNS name you will host CloudyMozDef at.
@@ -100,6 +108,7 @@ Resources:
     Properties:
       Parameters:
         VpcId: !Ref VpcId
+        SSHIngressCIDR: !Ref SSHIngressCIDR
       Tags:
         - Key: application
           Value: mozdef

--- a/cloudy_mozdef/cloudformation/mozdef-security-group.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-security-group.yml
@@ -4,6 +4,11 @@ Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id
     Description: The VPC ID of the VPC to deploy in
+  SSHIngressCIDR:
+    Type: String
+    AllowedPattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))?$'
+    ConstraintDescription: A valid CIDR (e.g. 203.0.113.0/24)
+    Description: The CIDR of IP addresses from which to allow inbound SSH connections
 Resources:
   MozDefSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -16,7 +21,7 @@ Resources:
       - IpProtocol: tcp
         FromPort: 22
         ToPort: 22
-        CidrIp: 0.0.0.0/0
+        CidrIp: !Ref SSHIngressCIDR
       - IpProtocol: tcp
         FromPort: 80
         ToPort: 80


### PR DESCRIPTION
This is to satisfy AWS Marketplace requirements to not
default to granting 0.0.0.0/0