### PR TITLE
Pin nginx container to mozillaiam/mozilla.oidc.accessproxy:8334f96

### DIFF
--- a/docker/compose/docker-compose-cloudy-mozdef.yml
+++ b/docker/compose/docker-compose-cloudy-mozdef.yml
@@ -2,7 +2,7 @@
 version: '2.2'
 services:
   nginx:
-    image: mozillaiam/mozilla.oidc.accessproxy
+    image: mozillaiam/mozilla.oidc.accessproxy:8334f96
     env_file:
       - cloudy_mozdef.env
     restart: always


### PR DESCRIPTION
This gets us mozilla-iam/mozilla.oidc.accessproxy#36 which works
around the bug in zmartzone/lua-resty-openidc#249