### PR TITLE
Revert part of #1079

### DIFF
--- a/cloudy_mozdef/cloudformation/mozdef-cloudtrail.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-cloudtrail.yml
@@ -64,7 +64,7 @@ Resources:
         - Sid: AllowSNSToSendToSQS
           Effect: Allow
           Principal:
-            AWS: !Join [ '', [ 'arn:', 'aws:', 'iam::', !Ref 'AWS::AccountId', ':root' ] ]
+            AWS: '*'
           Action: sqs:SendMessage
           Resource: !GetAtt MozDefCloudTrailSQSQueue.Arn
           Condition:


### PR DESCRIPTION
 as the ArnEquals Conditions is how to constrain access to the queue, not with Principal

https://docs.aws.amazon.com/sns/latest/dg/sns-sqs-as-subscriber.html#SendMessageToSQS.sqs.permissions

Fixes bug in #1079