### PR TITLE
Revert packer instance size change

### DIFF
--- a/cloudy_mozdef/packer/packer.json
+++ b/cloudy_mozdef/packer/packer.json
@@ -11,7 +11,7 @@
     "secret_key": "{{user `aws_secret_key`}}",
     "token": "{{user `aws_security_token`}}",
     "source_ami": "ami-0d1000aff9a9bad89",
-    "instance_type": "m5.large",
+    "instance_type": "t2.large",
     "ssh_pty" : "true",
     "ssh_username": "ec2-user",
     "ami_name": "mozdef_{{timestamp}}",


### PR DESCRIPTION
We found that the increased instance size didn't improve build time significantly