### PR TITLE
Make the docker environment variables available to cron jobs

### DIFF
--- a/docker/compose/docker-compose-cloudy-mozdef.yml
+++ b/docker/compose/docker-compose-cloudy-mozdef.yml
@@ -84,7 +84,7 @@ services:
     env_file:
       - cloudy_mozdef.env
     restart: always
-    command: bash -c 'crond -n'
+    command: bash -c 'cd / && bash launch_cron'
     volumes:
       - cron:/opt/mozdef/envs/mozdef/cron
       - geolite_db:/opt/mozdef/envs/mozdef/data/

--- a/docker/compose/mozdef_cron/Dockerfile
+++ b/docker/compose/mozdef_cron/Dockerfile
@@ -19,8 +19,12 @@ COPY docker/compose/mozdef_cron/files/healthToMongo.conf /opt/mozdef/envs/mozdef
 COPY docker/compose/mozdef_cron/files/syncAlertsToMongo.conf /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.conf
 
 RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/cron
+# https://stackoverflow.com/a/48651061/168874
+
+COPY docker/compose/mozdef_cron/files/launch_cron /launch_cron
 
 USER mozdef
 RUN crontab /cron_entries.txt
 
 USER root
+CMD ['/launch_cron']

--- a/docker/compose/mozdef_cron/Dockerfile
+++ b/docker/compose/mozdef_cron/Dockerfile
@@ -19,12 +19,13 @@ COPY docker/compose/mozdef_cron/files/healthToMongo.conf /opt/mozdef/envs/mozdef
 COPY docker/compose/mozdef_cron/files/syncAlertsToMongo.conf /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.conf
 
 RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/cron
-# https://stackoverflow.com/a/48651061/168874
 
+# https://stackoverflow.com/a/48651061/168874
 COPY docker/compose/mozdef_cron/files/launch_cron /launch_cron
 
 USER mozdef
 RUN crontab /cron_entries.txt
 
 USER root
-CMD ['/launch_cron']
+WORKDIR /
+CMD ['./launch_cron']

--- a/docker/compose/mozdef_cron/files/cron_entries.txt
+++ b/docker/compose/mozdef_cron/files/cron_entries.txt
@@ -1,3 +1,4 @@
+BASH_ENV=/env
 * * * * * /opt/mozdef/envs/mozdef/cron/healthAndStatus.sh
 * * * * * /opt/mozdef/envs/mozdef/cron/healthToMongo.sh
 * * * * * /opt/mozdef/envs/mozdef/cron/collectAttackers.sh

--- a/docker/compose/mozdef_cron/files/launch_cron
+++ b/docker/compose/mozdef_cron/files/launch_cron
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Export all root users environment variables, filtering out non custom variables and write them into /env
+declare -p | egrep -v ' HOSTNAME=| LS_COLORS=| TERM=| PATH=| PWD=| TZ=| SHLVL=| HOME=| LESSOPEN=| _=| affinity:container=| BASHOPTS=| BASH_VERSINFO=| EUID=| PPID=| SHELLOPTS=| UID=' > /env
+crond -n -x ext,sch,proc


### PR DESCRIPTION
cron jobs don't have access to the docker environment variables.
This, on instance launch, writes the environment to a file and
configured the mozdef crontab to use this on disk environment

This still needs the WORKDIR CMD fix to be added before merging