### PR TITLE
Revert #1155 to latest of mozilla.oidc.accessproxy

### DIFF
--- a/docker/compose/docker-compose-cloudy-mozdef.yml
+++ b/docker/compose/docker-compose-cloudy-mozdef.yml
@@ -2,7 +2,7 @@
 version: '2.2'
 services:
   nginx:
-    image: mozillaiam/mozilla.oidc.accessproxy:8334f96
+    image: mozillaiam/mozilla.oidc.accessproxy
     env_file:
       - cloudy_mozdef.env
     restart: always


### PR DESCRIPTION
Now that mozilla-iam/mozilla.oidc.accessproxy#36 is merged to master
and built and uploaded to dockerhub as tag `latest` we can go back
to using latest.

Note that in #1155 I updated the nginx container but missed the nginxkibana
container which should have also been pinned to 8334f96 dockerhub tag
resulting in only one of the two mozilla.oidc.accessproxy containers we
use to work correctly