### PR TITLE
Fix bug where deploy is publishing templates from branches and tags over master

### DIFF
--- a/cloudy_mozdef/Makefile
+++ b/cloudy_mozdef/Makefile
@@ -54,8 +54,7 @@ update-dev-stack: test ## Updates the nested stack on AWS
 	@export AWS_REGION=$(AWS_REGION)
 	aws cloudformation update-stack --stack-name $(STACK_NAME) --template-url $(S3_DEV_STACK_URI)mozdef-parent.yml \
 	  --capabilities CAPABILITY_IAM \
-	  --parameters ParameterKey=S3TemplateLocation,ParameterValue=$(S3_DEV_STACK_URI) \
-	               $(OIDC_CLIENT_SECRET_PARAM_ARG) \
+	  --parameters $(OIDC_CLIENT_SECRET_PARAM_ARG) \
 	               $(DEV_STACK_PARAMS) \
 	  --output text
 

--- a/cloudy_mozdef/ci/deploy
+++ b/cloudy_mozdef/ci/deploy
@@ -28,7 +28,7 @@ if [[ "branch/master" == "$CODEBUILD_WEBHOOK_TRIGGER" \
     cd cloudy_mozdef
     BRANCH="`echo $CODEBUILD_WEBHOOK_TRIGGER | cut -d '/' -f2`"
     make BRANCH=${BRANCH} packer-build-github
-    make publish-versioned-templates
+    make BRANCH=${BRANCH} publish-versioned-templates
     cd ..
     make BRANCH=${BRANCH} set-version-and-fetch-docker-container
     make BRANCH=${BRANCH} docker-push-tagged

--- a/cloudy_mozdef/ci/publish_versioned_templates
+++ b/cloudy_mozdef/ci/publish_versioned_templates
@@ -13,14 +13,16 @@ echo "  VariableMap:" >> "${AMI_MAP_TEMP_FILE}"
 echo "    Variables:" >> "${AMI_MAP_TEMP_FILE}"
 echo "      S3TemplateLocation: ${VERSIONED_STACK_URI}" >> "${AMI_MAP_TEMP_FILE}"
 
-# Inject the region AMI mapping into the mozdef-parent.yml file
+echo "Injecting the region AMI mapping into the mozdef-parent.yml CloudFormation template"
 sed '/# INSERT MAPPING HERE.*/{
     s/# INSERT MAPPING HERE.*//g
     r '"${AMI_MAP_TEMP_FILE}"'
 }' cloudformation/mozdef-parent.yml > ${TMPDIR}/mozdef-parent.yml
 
+echo "Uploading CloudFormation templates to S3 directory ${VERSIONED_BUCKET_URI}/"
 # Sync all .yml files except mozdef-parent.yml
 aws s3 sync cloudformation/ ${VERSIONED_BUCKET_URI} --exclude="*" --include="*.yml" --exclude="mozdef-parent.yml"
+# cp modified mozdef-parent.yml from TMPDIR to S3
 aws s3 cp ${TMPDIR}/mozdef-parent.yml ${VERSIONED_BUCKET_URI}/
 
 rm -rf "${TMPDIR}"


### PR DESCRIPTION
* Fix bug where deploy is publishing templates from branches and tags
  overwriting the /master branch directory in S3 instead of writing
  to their respective branch and tag specific directories
* Add log output and comments to publish_versioned_templates 
* Fix update-dev-stack, removing S3TemplateLocation
  * Similar to fc72de6 in #1154