### PR TITLE
Fix missing packer container fetch and other fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ run-tests: run-tests-resources  ## Just run the tests (no build/get). Use `make 
 	docker run -it --rm --network=test-mozdef_default mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && py.test --delete_indexes --delete_queues $(TEST_CASE)"
 rebuild-run-tests: build-tests run-tests
 
+.PHONY: build
+build: build-from-cwd
+
 .PHONY: build-from-cwd
 build-from-cwd:  ## Build local MozDef images (use make NO_CACHE=--no-cache build to disable caching)
 	docker-compose -f docker/compose/docker-compose.yml -p $(NAME) $(NO_CACHE) $(BUILD_MODE)

--- a/Makefile
+++ b/Makefile
@@ -153,4 +153,4 @@ new-alert: ## Create an example alert and working alert unit test
 
 .PHONY: set-version-and-fetch-docker-container
 set-version-and-fetch-docker-container: build-from-cwd tag-images # Lock the release of MozDef by pulling the docker containers on AMI build and caching replace all instances of latest in the compose override with the BRANCH
-	sed -i s/latest/$(BRANCH)/g docker/compose/docker-compose-cloudy-mozdef.yml
+	sed -i 's;\image: mozdef/\(.*\):latest$;image: mozdef/\1:$(BRANCH);g' docker/compose/docker-compose-cloudy-mozdef.yml

--- a/cloudy_mozdef/ci/deploy
+++ b/cloudy_mozdef/ci/deploy
@@ -30,7 +30,6 @@ if [[ "branch/master" == "$CODEBUILD_WEBHOOK_TRIGGER" \
     make BRANCH=${BRANCH} packer-build-github
     make BRANCH=${BRANCH} publish-versioned-templates
     cd ..
-    make BRANCH=${BRANCH} set-version-and-fetch-docker-container
     make BRANCH=${BRANCH} docker-push-tagged
 fi
 

--- a/cloudy_mozdef/packer/packer.json
+++ b/cloudy_mozdef/packer/packer.json
@@ -52,6 +52,7 @@
         "sudo git clone https://github.com/mozilla/MozDef /opt/mozdef",
         "cd /opt/mozdef && sudo git checkout {{ user `github_branch`}}",
         "cd /opt/mozdef && sudo make BRANCH={{ user `github_branch`}} set-version-and-fetch-docker-container",
+        "sudo docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p mozdef pull",
         "rm -rf /home/ec2-user/.ssh/authorized_keys",
         "rm -rf /home/ec2-user/.ssh/known_hosts",
         "sudo rm -rf /tmp/*",


### PR DESCRIPTION
* Add docker-compose pull to packer.json to fetch locally packages other than those we build Fixes #1163 
* Remove CodeBuild call to set-version-and-fetch-docker-container make target
  This is because
  * We've already built the containers in CodeBuild and don't need to do it again
  * We don't need to tag the docker images because `docker-push-tagged` will trigger that
  * We don't need to modify docker/compose/docker-compose-cloudy-mozdef.yml because we don't use it in CodeBuild
* Add build make target that mirrors previous behavior
  * Previous behavior of build was the build-from-cwd behavior
* Make the sed regex more specific so it only affects MozDef container images