### PR TITLE
Remove doc_type from mq

### DIFF
--- a/mq/esworker_cloudtrail.py
+++ b/mq/esworker_cloudtrail.py
@@ -259,6 +259,7 @@ def keyMapping(aDict):
             returndict['utctimestamp'] = toUTC(datetime.now()).isoformat()
         if 'type' not in returndict:
             # default replacement for old _type subcategory.
+            # to preserve filtering capabilities
             returndict['type'] = 'cloudtrail'
     except Exception as e:
         logger.exception(e)

--- a/mq/esworker_cloudtrail.py
+++ b/mq/esworker_cloudtrail.py
@@ -221,6 +221,7 @@ def keyMapping(aDict):
 
             elif k in ('type', 'eventtype', 'category'):
                 returndict[u'category'] = toUnicode(v)
+                returndict[u'type'] = 'cloudtrail'
 
             # custom fields as a list/array
             elif k in ('fields', 'details'):
@@ -257,10 +258,7 @@ def keyMapping(aDict):
         if 'utctimestamp' not in returndict:
             # default in case we don't find a reasonable timestamp
             returndict['utctimestamp'] = toUTC(datetime.now()).isoformat()
-        if 'type' not in returndict:
-            # default replacement for old _type subcategory.
-            # to preserve filtering capabilities
-            returndict['type'] = 'cloudtrail'
+
     except Exception as e:
         logger.exception(e)
         logger.error('Malformed message: %r' % aDict)

--- a/mq/esworker_cloudtrail.py
+++ b/mq/esworker_cloudtrail.py
@@ -257,6 +257,9 @@ def keyMapping(aDict):
         if 'utctimestamp' not in returndict:
             # default in case we don't find a reasonable timestamp
             returndict['utctimestamp'] = toUTC(datetime.now()).isoformat()
+        if 'type' not in returndict:
+            # default replacement for old _type subcategory.
+            returndict['type'] = 'cloudtrail'
     except Exception as e:
         logger.exception(e)
         logger.error('Malformed message: %r' % aDict)
@@ -369,7 +372,6 @@ class taskConsumer(object):
             # default elastic search metadata for an event
             metadata = {
                 'index': 'events',
-                'doc_type': 'cloudtrail',
                 'id': None
             }
             # just to be safe..check what we were sent.
@@ -416,7 +418,6 @@ class taskConsumer(object):
                 self.esConnection.save_event(
                     index=metadata['index'],
                     doc_id=metadata['id'],
-                    doc_type=metadata['doc_type'],
                     body=jbody,
                     bulk=bulk
                 )

--- a/mq/esworker_eventtask.py
+++ b/mq/esworker_eventtask.py
@@ -143,7 +143,10 @@ def keyMapping(aDict):
         if 'utctimestamp' not in returndict:
             # default in case we don't find a reasonable timestamp
             returndict['utctimestamp'] = toUTC(datetime.now()).isoformat()
+
         if 'type' not in returndict:
+            # default replacement for old _type subcategory.
+            # to preserve filtering capabilities
             returndict['type'] = 'event'
 
     except Exception as e:

--- a/mq/esworker_eventtask.py
+++ b/mq/esworker_eventtask.py
@@ -21,7 +21,6 @@ from mozdef_util.utilities.toUTC import toUTC
 from mozdef_util.utilities.logger import logger, initLogger
 from mozdef_util.utilities.to_unicode import toUnicode
 from mozdef_util.utilities.remove_at import removeAt
-from mozdef_util.utilities.is_cef import isCEF
 
 from lib.plugins import sendEventToPlugins, registerPlugins
 

--- a/mq/esworker_papertrail.py
+++ b/mq/esworker_papertrail.py
@@ -24,7 +24,6 @@ from mozdef_util.elasticsearch_client import ElasticsearchClient, ElasticsearchB
 from mozdef_util.utilities.toUTC import toUTC
 from mozdef_util.utilities.to_unicode import toUnicode
 from mozdef_util.utilities.remove_at import removeAt
-from mozdef_util.utilities.is_cef import isCEF
 from mozdef_util.utilities.logger import logger, initLogger
 
 from lib.plugins import sendEventToPlugins, registerPlugins

--- a/mq/esworker_papertrail.py
+++ b/mq/esworker_papertrail.py
@@ -203,7 +203,8 @@ def keyMapping(aDict):
             returndict['utctimestamp'] = toUTC(datetime.now()).isoformat()
 
         if 'type' not in returndict:
-            # add type subcategory for filtering
+            # default replacement for old _type subcategory.
+            # to preserve filtering capabilities
             returndict['type'] = 'event'
 
     except Exception as e:

--- a/mq/esworker_papertrail.py
+++ b/mq/esworker_papertrail.py
@@ -202,6 +202,10 @@ def keyMapping(aDict):
             # default in case we don't find a reasonable timestamp
             returndict['utctimestamp'] = toUTC(datetime.now()).isoformat()
 
+        if 'type' not in returndict:
+            # add type subcategory for filtering
+            returndict['type'] = 'event'
+
     except Exception as e:
         logger.exception('Received exception while normalizing message: %r' % e)
         logger.error('Malformed message: %r' % aDict)
@@ -270,7 +274,6 @@ class taskConsumer(object):
             # default elastic search metadata for an event
             metadata = {
                 'index': 'events',
-                'doc_type': 'event',
                 'id': None
             }
             # just to be safe..check what we were sent.
@@ -311,14 +314,6 @@ class taskConsumer(object):
             # make a json version for posting to elastic search
             jbody = json.JSONEncoder().encode(normalizedDict)
 
-            if isCEF(normalizedDict):
-                # cef records are set to the 'deviceproduct' field value.
-                metadata['doc_type'] = 'cef'
-                if 'details' in normalizedDict and 'deviceproduct' in normalizedDict['details']:
-                    # don't create strange doc types..
-                    if ' ' not in normalizedDict['details']['deviceproduct'] and '.' not in normalizedDict['details']['deviceproduct']:
-                        metadata['doc_type'] = normalizedDict['details']['deviceproduct']
-
             try:
                 bulk = False
                 if options.esbulksize != 0:
@@ -327,7 +322,6 @@ class taskConsumer(object):
                 self.esConnection.save_event(
                     index=metadata['index'],
                     doc_id=metadata['id'],
-                    doc_type=metadata['doc_type'],
                     body=jbody,
                     bulk=bulk
                 )

--- a/mq/esworker_sns_sqs.py
+++ b/mq/esworker_sns_sqs.py
@@ -107,6 +107,8 @@ class taskConsumer(object):
                         for inside_message_key, inside_message_value in message_json.iteritems():
                             if inside_message_key in ('type', 'category'):
                                 event['category'] = inside_message_value
+                                # add type subcategory for filtering after
+                                # original type field is rewritten as category
                                 event['type'] = 'event'
                             elif inside_message_key in ('processid', 'pid'):
                                 processid = str(inside_message_value)

--- a/mq/esworker_sns_sqs.py
+++ b/mq/esworker_sns_sqs.py
@@ -85,7 +85,6 @@ class taskConsumer(object):
             # default elastic search metadata for an event
             metadata = {
                 'index': 'events',
-                'doc_type': 'event',
                 'id': None
             }
             event = {}
@@ -106,7 +105,10 @@ class taskConsumer(object):
                     try:
                         message_json = json.loads(message_value)
                         for inside_message_key, inside_message_value in message_json.iteritems():
-                            if inside_message_key in ('processid', 'pid'):
+                            if inside_message_key in ('type', 'category'):
+                                event['category'] = inside_message_value
+                                event['type'] = 'event'
+                            elif inside_message_key in ('processid', 'pid'):
                                 processid = str(inside_message_value)
                                 processid = processid.replace('[', '')
                                 processid = processid.replace(']', '')
@@ -118,8 +120,6 @@ class taskConsumer(object):
                             elif inside_message_key in ('time', 'timestamp'):
                                 event['timestamp'] = toUTC(inside_message_value).isoformat()
                                 event['utctimestamp'] = toUTC(event['timestamp']).astimezone(pytz.utc).isoformat()
-                            elif inside_message_key in ('type', 'category'):
-                                event['category'] = inside_message_value
                             elif inside_message_key in ('summary','payload', 'message'):
                                 event['summary'] = inside_message_value.lstrip()
                             elif inside_message_key in ('source'):
@@ -162,7 +162,6 @@ class taskConsumer(object):
                 self.esConnection.save_event(
                     index=metadata['index'],
                     doc_id=metadata['id'],
-                    doc_type=metadata['doc_type'],
                     body=jbody,
                     bulk=bulk
                 )

--- a/mq/esworker_sqs.py
+++ b/mq/esworker_sqs.py
@@ -25,7 +25,6 @@ from ssl import SSLEOFError, SSLError
 from mozdef_util.utilities.toUTC import toUTC
 from mozdef_util.utilities.to_unicode import toUnicode
 from mozdef_util.utilities.remove_at import removeAt
-from mozdef_util.utilities.is_cef import isCEF
 from mozdef_util.utilities.logger import logger, initLogger
 from mozdef_util.elasticsearch_client import ElasticsearchClient, ElasticsearchBadServer, ElasticsearchInvalidIndex, ElasticsearchException
 

--- a/mq/plugins/auditdFixup.py
+++ b/mq/plugins/auditdFixup.py
@@ -113,5 +113,7 @@ class message(object):
         # add category
         if 'category' not in message:
             message['category'] = 'auditd'
+        # add type as a static entry
+        message['type'] = 'auditd'
 
         return (message, metadata)

--- a/mq/plugins/auditdFixup.py
+++ b/mq/plugins/auditdFixup.py
@@ -114,7 +114,4 @@ class message(object):
         if 'category' not in message:
             message['category'] = 'auditd'
 
-        # set doctype
-        metadata['doc_type'] = 'auditd'
-
         return (message, metadata)

--- a/mq/plugins/broFixup.py
+++ b/mq/plugins/broFixup.py
@@ -43,7 +43,8 @@ class message(object):
     def __init__(self):
         '''
         takes an incoming bro message
-        and sets the doc_type
+        and parses it to extract data
+        points and sets the type field
         '''
 
         self.registration = ['bro']
@@ -67,15 +68,12 @@ class message(object):
         if message['category'] != 'bro':
             return message, metadata
 
-        # set the doc type to bro
-        # to avoid data type conflicts with other doc types
-        # (int v string, etc)
-        # index holds documents of type 'type'
-        # index -> type -> doc
-        metadata['doc_type']= 'nsm'
-
         # move Bro specific fields under 'details' while preserving metadata
         newmessage = dict()
+
+        # default replacement for old _type subcategory.
+        # to preserve filtering capabilities
+        newmessage['type']= 'nsm'
 
         try:
             newmessage['details'] = json.loads(message['MESSAGE'])

--- a/mq/plugins/complianceitems.py
+++ b/mq/plugins/complianceitems.py
@@ -58,17 +58,21 @@ class message(object):
             The complianceitems plugin is called when an event
             is posted with a doctype 'complianceitems'.
             Compliance items are stored in the complianceitems
-            index, with doctype last_known_state
+            index, with a type of last_known_state. The doc_type
+            is overwritten with _doc.
         """
         if not self.validate(message['details']):
             logger.error('Invalid format for complianceitem {0}'.format(message))
             return (None, None)
+        if 'type' not in message:
+            # add type subcategory for filtering
+            message['type'] = 'last_known_state'
+
         item = self.cleanup_item(message['details'])
         docidstr = 'complianceitems'
         docidstr += item['check']['ref']
         docidstr += item['check']['test']['value']
         docidstr += item['target']
         metadata['id'] = hashlib.md5(docidstr).hexdigest()
-        metadata['doc_type'] = 'last_known_state'
         metadata['index'] = 'complianceitems'
         return (item, metadata)

--- a/mq/plugins/complianceitems.py
+++ b/mq/plugins/complianceitems.py
@@ -64,9 +64,8 @@ class message(object):
         if not self.validate(message['details']):
             logger.error('Invalid format for complianceitem {0}'.format(message))
             return (None, None)
-        if 'type' not in message:
-            # add type subcategory for filtering
-            message['type'] = 'last_known_state'
+        # add type subcategory for filtering
+        message['type'] = 'last_known_state'
 
         item = self.cleanup_item(message['details'])
         docidstr = 'complianceitems'

--- a/mq/plugins/customDocType.py
+++ b/mq/plugins/customDocType.py
@@ -8,19 +8,17 @@ class message(object):
     def __init__(self):
         '''
         takes an incoming custom endpoint message
-        and sets the doc_type
+        and sets the type sub-category filter
         '''
 
         self.registration = ['customendpoint']
         self.priority = 2
 
     def onMessage(self, message, metadata):
-        # set the doc type
-        # to avoid data type conflicts with other doc types
-        # (int vs string, etc)
+        # set the type field for sub-categorical filtering
         if 'endpoint' in message and 'customendpoint' in message:
             if message['customendpoint']:
                 if isinstance(message['endpoint'], str) or \
                    isinstance(message['endpoint'], unicode):
-                    metadata['doc_type']= message['endpoint']
+                    message['type'] = message['endpoint']
         return (message, metadata)

--- a/mq/plugins/dropMessage.py
+++ b/mq/plugins/dropMessage.py
@@ -17,7 +17,7 @@ class message(object):
         # this plugin inspects messages for whitelist stuff that
         # should be dropped and not processed any further.
         rdict = dict()
-        rdict['_type'] = 'auditd'
+        rdict['type'] = 'auditd'
         rdict['details'] = dict()
         rdict['details']['http_user_agent'] = 'ELB-HealthChecker/1.0'
         self.registration = rdict

--- a/mq/plugins/googleFixup.py
+++ b/mq/plugins/googleFixup.py
@@ -8,7 +8,7 @@ class message(object):
     def __init__(self):
         '''
         takes an incoming message
-        and sets the doc_type
+        and sets the type
         '''
 
         self.registration = ['google']
@@ -26,6 +26,6 @@ class message(object):
             if 'etag' in message['details']:
                 message['details']['etag'] = message['details']['etag'].replace('"', '')
 
-            metadata['doc_type'] = 'google'
+            message['type'] = 'google'
 
         return (message, metadata)

--- a/mq/plugins/ipFixup.py
+++ b/mq/plugins/ipFixup.py
@@ -48,12 +48,10 @@ class message(object):
         Also sets ipv4 in two fields:
             ipaddress (decimal mapping IP)
             ipv4address (string mapping)
-            Elastic search is inconsistent about returning IPs as
-            decimal or IPs.
-            In a query an IP field is returned as string.
-            In a facets an IP field is returned as decimal.
-            No ES field type exists for ipv6, so always having
-            a string version is the most flexible option.
+            While the IP field-type serves for IPv4 or IPv6,
+            it is not quite mature yet as kibana lacks filtering
+            to differentiate between IPv4 and IPv6, so always
+            having a string version is the most flexible option.
         '''
 
         if 'details' in message:

--- a/mq/plugins/netflowFixup.py
+++ b/mq/plugins/netflowFixup.py
@@ -8,16 +8,14 @@ class message(object):
     def __init__(self):
         '''
         takes an incoming message
-        and sets the doc_type
+        and sets the type field
         '''
 
         self.registration = ['netflow']
         self.priority = 5
 
     def onMessage(self, message, metadata):
-        # set the doc type
-        # to avoid data type conflicts with other doc types
-        # (int v string, etc)
-        metadata['doc_type']= 'netflow'
+        # set the type field for sub-categorical filtering
+        message['type']= 'netflow'
 
         return (message, metadata)

--- a/mq/plugins/parse_sshd.py
+++ b/mq/plugins/parse_sshd.py
@@ -10,8 +10,9 @@ class message(object):
 
     def __init__(self):
         '''
-        takes an incoming sshd message and
-        parses sshd details into fields
+        takes an incoming sshd message
+        and sets the doc_type
+        and parses the message for data points
         '''
 
         self.registration = ['sshd']

--- a/mq/plugins/parse_su.py
+++ b/mq/plugins/parse_su.py
@@ -13,8 +13,8 @@ class message(object):
 
     def __init__(self):
         '''
-        takes an incoming sshd message
-        and sets the doc_type
+        takes an incoming su message
+        and parses it to extract data points
         '''
 
         self.registration = ['sshd']

--- a/mq/plugins/squidFixup.py
+++ b/mq/plugins/squidFixup.py
@@ -15,8 +15,10 @@ from netaddr import valid_ipv4
 class message(object):
     def __init__(self):
         """
-        takes an incoming bro message
-        and sets the doc_type
+        takes an incoming squid event
+        and parses the message to extract 
+        data points, and sets the type 
+        field
         """
 
         self.registration = ["squid"]
@@ -71,15 +73,11 @@ class message(object):
         if message["category"] != "proxy":
             return message, metadata
 
-        # Reuse the NSM doc type
-        # to avoid data type conflicts with other doc types
-        # (int v string, etc)
-        # index holds documents of type 'type'
-        # index -> type -> doc
-        metadata["doc_type"] = "nsm"
-
         # move Squid specific fields under 'details' while preserving metadata
         newmessage = dict()
+
+        # Set NSM as type for categorical filtering of events.
+        newmessage["type"] = "nsm"
 
         newmessage[u"mozdefhostname"] = self.mozdefhostname
         newmessage["details"] = {}

--- a/mq/plugins/squidFixup.py
+++ b/mq/plugins/squidFixup.py
@@ -77,7 +77,7 @@ class message(object):
         newmessage = dict()
 
         # Set NSM as type for categorical filtering of events.
-        newmessage["type"] = "nsm"
+        newmessage["type"] = "squid"
 
         newmessage[u"mozdefhostname"] = self.mozdefhostname
         newmessage["details"] = {}

--- a/mq/plugins/squidFixup.py
+++ b/mq/plugins/squidFixup.py
@@ -16,8 +16,8 @@ class message(object):
     def __init__(self):
         """
         takes an incoming squid event
-        and parses the message to extract 
-        data points, and sets the type 
+        and parses the message to extract
+        data points, and sets the type
         field
         """
 

--- a/mq/plugins/suricataFixup.py
+++ b/mq/plugins/suricataFixup.py
@@ -13,8 +13,8 @@ class message(object):
     def __init__(self):
         '''
         takes an incoming suricata event
-        and parses the message to extract 
-        data points, and sets the type 
+        and parses the message to extract
+        data points, and sets the type
         field
         '''
 

--- a/mq/plugins/suricataFixup.py
+++ b/mq/plugins/suricataFixup.py
@@ -12,8 +12,10 @@ from mozdef_util.utilities.toUTC import toUTC
 class message(object):
     def __init__(self):
         '''
-        takes an incoming bro message
-        and sets the doc_type
+        takes an incoming suricata event
+        and parses the message to extract 
+        data points, and sets the type 
+        field
         '''
 
         self.registration = ['suricata']
@@ -35,15 +37,11 @@ class message(object):
         if message['category'] != 'suricata':
             return message, metadata
 
-        # set the doc type to nsm
-        # to avoid data type conflicts with other doc types
-        # (int v string, etc)
-        # index holds documents of type 'type'
-        # index -> type -> doc
-        metadata['doc_type']= 'nsm'
-
         # move Suricata specific fields under 'details' while preserving metadata
         newmessage = dict()
+
+        # Set NSM as type for categorical filtering of events.
+        newmessage["type"] = "nsm"
 
         try:
             newmessage['details'] = json.loads(message['message'])

--- a/mq/plugins/vidyoCallID.py
+++ b/mq/plugins/vidyoCallID.py
@@ -14,14 +14,12 @@ class message(object):
         '''
 
         # this plugin
-        # sets a static document ID
-        # for a particular event to allow you to have an event that just updates
-        # current status
+        # sets the type field
         self.registration = ['uniquecallid']
         self.priority = 5
 
     def onMessage(self, message, metadata):
         docid = hashlib.md5('vidyouniquecallid' + message['details']['uniquecallid']).hexdigest()
         metadata['id'] = docid
-        metadata['doc_type'] = 'vidyo'
+        message['type'] = 'vidyo'
         return (message, metadata)

--- a/mq/plugins/vulnerability.py
+++ b/mq/plugins/vulnerability.py
@@ -77,7 +77,7 @@ class message(object):
         return hashlib.md5(s).hexdigest()
 
     def onMessage(self, message, metadata):
-        if metadata['doc_type'] != 'vulnerability':
+        if message['type'] != 'vulnerability':
             return (message, metadata)
         handler = self.get_handler(message)
         if handler is None:
@@ -86,6 +86,6 @@ class message(object):
             logger.error('Invalid format for vulnerability {0}'.format(message))
             return (None, None)
         metadata['id'] = handler.calculate_id(message)
-        metadata['doc_type'] = 'vulnerability_state'
+        message['type'] = 'vulnerability_state'
         metadata['index'] = 'vulnerabilities'
         return (message, metadata)


### PR DESCRIPTION
Replaces https://github.com/mozilla/MozDef/pull/1130

        modified:   mq/esworker_cloudtrail.py
        modified:   mq/esworker_eventtask.py
        modified:   mq/esworker_papertrail.py
        modified:   mq/esworker_sns_sqs.py
        modified:   mq/esworker_sqs.py
        modified:   mq/plugins/auditdFixup.py
        modified:   mq/plugins/broFixup.py
        modified:   mq/plugins/complianceitems.py
        modified:   mq/plugins/customDocType.py
        modified:   mq/plugins/dropMessage.py
        modified:   mq/plugins/googleFixup.py
        modified:   mq/plugins/ipFixup.py
        modified:   mq/plugins/netflowFixup.py
        modified:   mq/plugins/parse_sshd.py
        modified:   mq/plugins/parse_su.py
        modified:   mq/plugins/squidFixup.py
        modified:   mq/plugins/suricataFixup.py
        modified:   mq/plugins/vidyoCallID.py
        modified:   mq/plugins/vulnerability.py

- Removed doc_type (_type) references.
- Added type references (which take on the value that _type held).
- Modified verbiage in some files for accuracy.


Must inform about vulnerability.py changes to @arcrose prior to committing this change to master.
