### PR TITLE
Fix docker push and tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,46 +107,14 @@ hub: ## Upload locally built MozDef images tagged as the current git head (hub.d
 
 .PHONY: tag-images
 tag-images:
-	docker tag mozdef/mozdef_meteor:latest mozdef/mozdef_meteor:$(BRANCH)
-	docker tag mozdef/mozdef_base:latest mozdef/mozdef_base:$(BRANCH)
-	docker tag mozdef/mozdef_tester:latest mozdef/mozdef_tester:$(BRANCH)
-	docker tag mozdef/mozdef_mq_worker:latest mozdef/mozdef_mq_worker:$(BRANCH)
-	docker tag mozdef/mozdef_kibana:latest mozdef/mozdef_kibana:$(BRANCH)
-	docker tag mozdef/mozdef_syslog:latest mozdef/mozdef_syslog:$(BRANCH)
-	docker tag mozdef/mozdef_cron:latest mozdef/mozdef_cron:$(BRANCH)
-	docker tag mozdef/mozdef_elasticsearch:latest mozdef/mozdef_elasticsearch:$(BRANCH)
-	docker tag mozdef/mozdef_loginput:latest mozdef/mozdef_loginput:$(BRANCH)
-	docker tag mozdef/mozdef_mongodb:latest mozdef/mozdef_mongodb:$(BRANCH)
-	docker tag mozdef/mozdef_bootstrap:latest mozdef/mozdef_bootstrap:$(BRANCH)
-	docker tag mozdef/mozdef_alerts:latest mozdef/mozdef_alerts:$(BRANCH)
-	docker tag mozdef/mozdef_nginx:latest mozdef/mozdef_nginx:$(BRANCH)
-	docker tag mozdef/mozdef_alertactions:latest mozdef/mozdef_alertactions:$(BRANCH)
-	docker tag mozdef/mozdef_rabbitmq:latest mozdef/mozdef_rabbitmq:$(BRANCH)
-	docker tag mozdef/mozdef_rest:latest mozdef/mozdef_rest:$(BRANCH)
-	docker tag mozdef/mozdef_base:latest mozdef/mozdef_base:$(BRANCH)
+	cloudy_mozdef/ci/docker_tag_or_push tag $(BRANCH)
 
 .PHONY: docker-push-tagged
 docker-push-tagged: tag-images hub-tagged
 
 .PHONY: hub-tagged
 hub-tagged: ## Upload locally built MozDef images tagged as the BRANCH.  Branch and tagged release are interchangeable here.
-	docker push mozdef/mozdef_meteor:$(BRANCH)
-	docker push mozdef/mozdef_base:$(BRANCH)
-	docker push mozdef/mozdef_tester:$(BRANCH)
-	docker push mozdef/mozdef_mq_worker:$(BRANCH)
-	docker push mozdef/mozdef_kibana:$(BRANCH)
-	docker push mozdef/mozdef_syslog:$(BRANCH)
-	docker push mozdef/mozdef_cron:$(BRANCH)
-	docker push mozdef/mozdef_elasticsearch:$(BRANCH)
-	docker push mozdef/mozdef_loginput:$(BRANCH)
-	docker push mozdef/mozdef_mongodb:$(BRANCH)
-	docker push mozdef/mozdef_bootstrap:$(BRANCH)
-	docker push mozdef/mozdef_alerts:$(BRANCH)
-	docker push mozdef/mozdef_nginx:$(BRANCH)
-	docker push mozdef/mozdef_alertactions:$(BRANCH)
-	docker push mozdef/mozdef_rabbitmq:$(BRANCH)
-	docker push mozdef/mozdef_rest:$(BRANCH)
-	docker push mozdef/mozdef_base:$(BRANCH)
+	cloudy_mozdef/ci/docker_tag_or_push push $(BRANCH)
 
 .PHONY: docker-get
 docker-get: hub-get

--- a/cloudy_mozdef/ci/docker_tag_or_push
+++ b/cloudy_mozdef/ci/docker_tag_or_push
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+action="${1}"
+branch="${2}"
+
+for name in mozdef_meteor mozdef_base mozdef_tester mozdef_mq_worker mozdef_kibana \
+        mozdef_syslog mozdef_cron mozdef_elasticsearch mozdef_loginput mozdef_mongodb \
+        mozdef_bootstrap mozdef_alerts mozdef_nginx mozdef_alertactions mozdef_rabbitmq \
+        mozdef_rest mozdef_base ; do
+    if [ "${action}" == "tag" ]; then
+        if [ "${branch}" == "master" ]; then
+            docker tag mozdef/${name}:latest mozdef/${name}:${branch}
+        else
+            docker tag mozdef/${name}:${branch}
+        fi
+    elif [ "${action}" == "push" ]; then
+        docker push mozdef/${name}:${branch}
+        if [ "${branch}" == "master" ]; then
+            docker push mozdef/${name}:latest
+        fi
+    fi
+done


### PR DESCRIPTION
* Only tag an image as latest if it came from master branch
* Upload images to dockerhub tagged as latest in addition to those tagged as the branch