### PR TITLE
Define python version for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+python:
+  - "2.7"
 sudo: required
 services:
   - docker


### PR DESCRIPTION
Apr 16, 2019 the default changes from 2.7 to 3.6. This will keep it at 2.7