### PR TITLE
Change CI/CD sequence for v1.38.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,9 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ## [v1.38.5] - 2019-04-09
+### Added
+- Support for CSS themes
+
 ### Changed
-- Changed the CI/CD order to now build docker images in CodeBuild, upload them
+- The CI/CD order to now build docker images in CodeBuild, upload them
   to DockerHub and then pull them down in the packer instance. Updated docs.
+- Assert TravisCI Python version in advance of change of Travis default to 3.6
+
+### Fixed
+- Dashboard error on docker spinup
+
 
 ## [v1.38.4] - 2019-04-08
 ### Fixed

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [v1.38.5] - 2019-04-09
+### Changed
+- Changed the CI/CD order to now build docker images in CodeBuild, upload them
+  to DockerHub and then pull them down in the packer instance. Updated docs.
+
 ## [v1.38.4] - 2019-04-08
 ### Fixed
 - Docker image tagging for git version tag builds
@@ -64,7 +69,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added checks on sending SQS messages to only accept intra-account messages
 - Improved docker performance and disk space requirements
 
-[Unreleased]: https://github.com/mozilla/MozDef/compare/v1.38.4...HEAD
+[Unreleased]: https://github.com/mozilla/MozDef/compare/v1.38.5...HEAD
+[v1.38.5]: https://github.com/mozilla/MozDef/compare/v1.38.4...v1.38.5
 [v1.38.4]: https://github.com/mozilla/MozDef/compare/v1.38.3...v1.38.4
 [v1.38.3]: https://github.com/mozilla/MozDef/compare/v1.38.2...v1.38.3
 [v1.38.2]: https://github.com/mozilla/MozDef/compare/v1.38.1...v1.38.2

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,3 @@ rebuild: clean build-from-cwd
 .PHONY: new-alert
 new-alert: ## Create an example alert and working alert unit test
 	python tests/alert_templater.py
-
-.PHONY: set-version-and-fetch-docker-container
-set-version-and-fetch-docker-container: build-from-cwd tag-images # Lock the release of MozDef by pulling the docker containers on AMI build and caching replace all instances of latest in the compose override with the BRANCH
-	sed -i s/latest/$(BRANCH)/g docker/compose/docker-compose-cloudy-mozdef.yml

--- a/cloudy_mozdef/ci/deploy
+++ b/cloudy_mozdef/ci/deploy
@@ -15,20 +15,20 @@ echo "It's dangerous to go alone.  Take one of these: <%%%%|==========>"
 # Then again we probably do not need to run the test suite here because it has been run three times to get the code here.
 # echo "Tests complete.
 
-echo "Processing webhook event for ${CODEBUILD_WEBHOOK_TRIGGER}."
+echo "Processing webhook event for '${CODEBUILD_WEBHOOK_TRIGGER}'."
 
 if [[ "branch/master" == "$CODEBUILD_WEBHOOK_TRIGGER" \
         || "$CODEBUILD_WEBHOOK_TRIGGER" =~ ^tag\/v[0-9]+\.[0-9]+\.[0-9]+(\-(prod|pre|testing))?$ ]]; then
     echo "Building a release"
     echo "C|_| This may take a bit.  Might as well grab a coffee."
-    make build-from-cwd
-    cd cloudy_mozdef
     BRANCH="`echo $CODEBUILD_WEBHOOK_TRIGGER | cut -d '/' -f2`"
+    make build-from-cwd
+    make hub-login
+    make BRANCH=${BRANCH} docker-push-tagged
+    cd cloudy_mozdef
     make BRANCH=${BRANCH} packer-build-github
     make BRANCH=${BRANCH} publish-versioned-templates
     cd ..
-    make hub-login
-    make BRANCH=${BRANCH} docker-push-tagged
 fi
 
 echo "End build of the MozDef codebase."

--- a/cloudy_mozdef/packer/packer.json
+++ b/cloudy_mozdef/packer/packer.json
@@ -1,72 +1,69 @@
 {
   "variables": {
-      "aws_access_key":     "{{env `AWS_ACCESS_KEY_ID`}}",
-      "aws_secret_key":     "{{env `AWS_SECRET_ACCESS_KEY`}}",
-      "aws_security_token": "{{env `AWS_SESSION_TOKEN`}}"
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "aws_security_token": "{{env `AWS_SESSION_TOKEN`}}"
   },
-  "builders": [{
-    "type": "amazon-ebs",
-    "region": "us-west-2",
-    "access_key": "{{user `aws_access_key`}}",
-    "secret_key": "{{user `aws_secret_key`}}",
-    "token": "{{user `aws_security_token`}}",
-    "source_ami": "ami-0d1000aff9a9bad89",
-    "instance_type": "t2.large",
-    "ssh_pty" : "true",
-    "ssh_username": "ec2-user",
-    "ami_name": "mozdef_{{timestamp}}",
-    "launch_block_device_mappings": [
-      {
-      "delete_on_termination": true,
-      "device_name": "/dev/xvda",
-      "volume_size": 14
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "us-west-2",
+      "access_key": "{{user `aws_access_key`}}",
+      "secret_key": "{{user `aws_secret_key`}}",
+      "token": "{{user `aws_security_token`}}",
+      "source_ami": "ami-0d1000aff9a9bad89",
+      "instance_type": "t2.large",
+      "ssh_pty": "true",
+      "ssh_username": "ec2-user",
+      "ami_name": "mozdef_{{timestamp}}",
+      "launch_block_device_mappings": [
+        {
+          "delete_on_termination": true,
+          "device_name": "/dev/xvda",
+          "volume_size": 14
+        }
+      ],
+      "ami_description": "An automated build of MozDef triggered via the makefile.",
+      "ami_groups": [
+        "all"
+      ],
+      "run_tags": {
+        "app": "packer-builder-mozdef"
+      },
+      "run_volume_tags": {
+        "app": "packer-builder-mozdef"
+      },
+      "snapshot_tags": {
+        "app": "packer-builder-mozdef"
+      },
+      "tags": {
+        "github:Branch": "{{ user `github_branch`}}",
+        "buildTimestamp": "{{timestamp}}",
+        "app": "mozdef"
       }
-    ],
-    "ami_description": "An automated build of MozDef triggered via the makefile.",
-    "ami_groups": [
-      "all"
-    ],
-    "run_tags": {
-      "app": "packer-builder-mozdef"
-    },
-    "run_volume_tags": {
-      "app": "packer-builder-mozdef"
-    },
-    "snapshot_tags": {
-      "app": "packer-builder-mozdef"
-    },
-    "tags": {
-      "github:Branch": "{{ user `github_branch`}}",
-      "buildTimestamp": "{{timestamp}}",
-      "app": "mozdef"
     }
-  }],
- "provisioners": [
-   {  "type": "shell",
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
       "inline": [
+        "set -e",
         "sudo yum update -y",
         "sudo yum makecache fast",
-        "sudo yum install -y glibc-devel gcc libstdc++ libffi-devel zlib-devel make ",
-        "sudo yum install -y mysql-devel python python-devel python-pip",
-        "sudo yum install -y git",
-        "sudo yum install -y docker",
-        "sudo yum install -y python3",
-        "sudo pip install virtualenv ",
-        "sudo pip install docker-compose",
+        "sudo yum install -y glibc-devel gcc libstdc++ libffi-devel zlib-devel make mysql-devel python python-devel python-pip git docker python3",
+        "sudo pip install virtualenv docker-compose",
         "sudo systemctl enable docker",
         "sudo systemctl start docker",
-        "sudo mkdir -p /opt/mozdef/",
+        "sudo mkdir --verbose --parents /opt/mozdef/",
         "sudo git clone https://github.com/mozilla/MozDef /opt/mozdef",
-        "cd /opt/mozdef && sudo git checkout {{ user `github_branch`}}",
-        "cd /opt/mozdef && sudo git rev-parse HEAD",
-        "cd /opt/mozdef && sudo touch docker/compose/cloudy_mozdef.env docker/compose/rabbitmq.env docker/compose/cloudy_mozdef_mq_cloudtrail.env docker/compose/cloudy_mozdef_mq_sns_sqs.env docker/compose/cloudy_mozdef_kibana.env",
-        "cd /opt/mozdef && sudo make BRANCH={{ user `github_branch`}} set-version-and-fetch-docker-container",
-        "cd /opt/mozdef && sudo docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p mozdef pull",
-        "rm -rf /home/ec2-user/.ssh/authorized_keys",
-        "rm -rf /home/ec2-user/.ssh/known_hosts",
-        "sudo rm -rf /tmp/*",
-        "sudo rm -rf /home/ec2-user/.bash_history",
-        "sudo rm -rf /root/.ssh"
-      ]}
- ]
+        "cd /opt/mozdef",
+        "sudo git checkout {{ user `github_branch`}}",
+        "sudo git rev-parse HEAD",
+        "sudo touch docker/compose/cloudy_mozdef.env docker/compose/rabbitmq.env docker/compose/cloudy_mozdef_mq_cloudtrail.env docker/compose/cloudy_mozdef_mq_sns_sqs.env docker/compose/cloudy_mozdef_kibana.env",
+        "sudo sed --in-place s/latest/{{ user `github_branch`}}/g docker/compose/docker-compose-cloudy-mozdef.yml",
+        "sudo docker-compose --file docker/compose/docker-compose-cloudy-mozdef.yml --project-name mozdef pull",
+        "sudo rm --recursive --force --verbose /tmp/* /home/ec2-user/.bash_history /root/.ssh /home/ec2-user/.ssh/known_hosts /home/ec2-user/.ssh/authorized_keys"
+      ]
+    }
+  ]
 }

--- a/docker/compose/mozdef_meteor/Dockerfile
+++ b/docker/compose/mozdef_meteor/Dockerfile
@@ -46,7 +46,8 @@ RUN mkdir -p /opt/mozdef/envs/meteor/mozdef
 RUN if [ "${METEOR_BUILD}" = "YES" ]; then \
         cd /opt/mozdef/envs/mozdef/meteor && \
         meteor npm install && \
-        meteor build --server localhost:3002 --directory /opt/mozdef/envs/meteor/mozdef && \
+        echo "Starting meteor build" && \
+        time meteor build --server localhost:3002 --directory /opt/mozdef/envs/meteor/mozdef && \
         cp -r /opt/mozdef/envs/mozdef/meteor/node_modules /opt/mozdef/envs/meteor/mozdef/node_modules &&\
         cd /opt/mozdef/envs/meteor/mozdef/bundle/programs/server && \
         npm install ;\


### PR DESCRIPTION
Changed the CI/CD order to now build docker images in CodeBuild, upload them
to DockerHub and then pull them down in the packer instance. Updated docs.

I confirmed this one works in a branch and built a new stack and updated an existing stack with the resulting artifacts.