### PR TITLE
Generalize config copy to allow for other worker processes

### DIFF
--- a/docker/compose/mozdef_mq_worker/Dockerfile
+++ b/docker/compose/mozdef_mq_worker/Dockerfile
@@ -3,7 +3,7 @@ FROM mozdef/mozdef_base
 LABEL maintainer="mozdef@mozilla.com"
 
 COPY mq /opt/mozdef/envs/mozdef/mq
-COPY docker/compose/mozdef_mq_worker/files/esworker_eventtask.conf /opt/mozdef/envs/mozdef/mq/esworker_eventtask.conf
+COPY docker/compose/mozdef_mq_worker/files/*.conf /opt/mozdef/envs/mozdef/mq/
 
 RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/mq
 


### PR DESCRIPTION
This allows us to have multiple .conf files in other deployment processes without having to modify the dockerfile.