### PR TITLE
Update docs to point to current release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ MozDef is in production at Mozilla where we are using it to process over 300 mil
 
 ## Give MozDef a Try in AWS:
 
-[![Launch MozDef](docs/source/images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=mozdef-for-aws&templateURL=https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/mozdef/cf/mozdef-parent.yml)
+[![Launch MozDef](docs/source/images/cloudformation-launch-stack.png)][1]
 
 ## Documentation:
 
 http://mozdef.readthedocs.org/en/latest/
+
+[1]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=mozdef-for-aws&templateURL=https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/mozdef/cf/v1.38.5/mozdef-parent.yml

--- a/docs/source/cicd.rst
+++ b/docs/source/cicd.rst
@@ -143,7 +143,7 @@ __________________
 
   * Within this ec2 instance, packer `clones the MozDef GitHub repo and checks
     out the branch that triggered this build
-    <https://github.com/mozilla/MozDef/blob/cfeafb77f9d4d4d8df02117a0ffca0ec9379a7d5/cloudy_mozdef/packer/packer.json#L59-L60>`_
+    <https://github.com/mozilla/MozDef/blob/c7a166f2e29dde8e5d71853a279fb0c47a48e1b2/cloudy_mozdef/packer/packer.json#L58-L60>`_
   * packer replaces all instances of the word `latest` in the
     `docker-compose-cloudy-mozdef.yml <https://github.com/mozilla/MozDef/blob/master/docker/compose/docker-compose-cloudy-mozdef.yml>`_
     file with either the branch `master` or the version tag (e.g. `v1.2.3`)

--- a/docs/source/cloud_deployment.rst
+++ b/docs/source/cloud_deployment.rst
@@ -7,7 +7,7 @@ Cloud based MozDef is an opinionated deployment of the MozDef services created i
 ingest CloudTrail, GuardDuty, and provide security services.
 
 .. image:: images/cloudformation-launch-stack.png
-   :target: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=mozdef-for-aws&templateURL=https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/mozdef/cf/mozdef-parent.yml
+   :target: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/new?stackName=mozdef-for-aws&templateURL=https://s3-us-west-2.amazonaws.com/public.us-west-2.infosec.mozilla.org/mozdef/cf/v1.38.5/mozdef-parent.yml
 
 
 Feedback


### PR DESCRIPTION
The links to mozdef-parent.yml point to the wrong place currently

Also, update documentation link to packer.json 