### PR TITLE
adding basic license config, disables pay for features in kibana.

### DIFF
--- a/docker/compose/elasticsearch/files/elasticsearch.yml
+++ b/docker/compose/elasticsearch/files/elasticsearch.yml
@@ -9,6 +9,7 @@ action.auto_create_index:  .watches,.triggered_watches,.watcher-history-*
 
 # Add these to prevent requiring a user/pass and termination of ES when looking for "ingest" assignments.
 # The watcher directive allows for the deletion of failed watcher indices as they sometimes get created with glitches.
+xpack.license.self_generated.type: basic
 xpack.security.enabled: false
 xpack.monitoring.exporters.my_local:
   type: local


### PR DESCRIPTION
After 30 days the default trial license expires and generates a warning message at the top of kibana.
To make this not happen, this line will turn on the default basic licensing which will disable the "pay-for" features of kibana.

Feel free to close this PR, as the trial license expires there is an option inside the kibana license management to downgrade to the basic license without having this in the kibana config. I only added this to bring awareness and start dialogue should this be considered a desired configuration.

Features turned off:
https://www.elastic.co/guide/en/x-pack/current/license-expiration.html
- **Watcher**
- **Monitoring**
- **Graph**
- **Reporting**
- **Security**
- **Machine learning**
- **Logstash Pipeline Management**

Once the license expires, calls to the cluster health, cluster stats, and index stats APIs fail with a security_exception and return a 403 HTTP status code.

{
  "error": {
    "root_cause": [
      {
        "type": "security_exception",
        "reason": "current license is non-compliant for [security]",
        "license.expired.feature": "security"
      }
    ],
    "type": "security_exception",
    "reason": "current license is non-compliant for [security]",
    "license.expired.feature": "security"
  },
  "status": 403
}

This message enables automatic monitoring systems to easily detect the license failure without immediately impacting other users.
    