### PR TITLE
Add case to pass on import errors (after logging)

### DIFF
--- a/alerts/celeryconfig.py
+++ b/alerts/celeryconfig.py
@@ -66,6 +66,10 @@ for alert_namespace in CELERYBEAT_SCHEDULE:
         alert_module = import_module(alert_module_name)
         alert_class = getattr(alert_module, alert_classname)
         app.register_task(alert_class())
+    except ImportError as e:
+        print "Error importing {}".format(alert_namespace)
+        print e
+        pass 
     except Exception as e:
         print "Error addding alert"
         print e

--- a/alerts/celeryconfig.py
+++ b/alerts/celeryconfig.py
@@ -69,7 +69,7 @@ for alert_namespace in CELERYBEAT_SCHEDULE:
     except ImportError as e:
         print "Error importing {}".format(alert_namespace)
         print e
-        pass 
+        pass
     except Exception as e:
         print "Error addding alert"
         print e


### PR DESCRIPTION
My last commit in this vein just made the error apparent. This commit allows for entries to exist in the schedule which are not importable and for the alerts container to carry on without them.