### PR TITLE
Use systemd to launch docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,6 @@ all:
 run: build ## Run all MozDef containers
 	docker-compose -f docker/compose/docker-compose.yml -p $(NAME) up -d
 
-.PHONY: run-cloudy-mozdef
-run-cloudy-mozdef: ## Run the MozDef containers necessary to run in AWS (`cloudy-mozdef`). This is used by the CloudFormation-initiated setup.
-	$(shell test -f docker/compose/cloudy_mozdef.env || touch docker/compose/cloudy_mozdef.env)
-	$(shell test -f docker/compose/cloudy_mozdef_kibana.env || touch docker/compose/cloudy_mozdef_kibana.env)
-	# docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p $(NAME) pull  # Images are now in the local packer build AMI and no docker pull is needed
-	docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p $(NAME) up -d
-
 .PHONY: run-env-mozdef
 run-env-mozdef: ## Run the MozDef containers with a user specified env file. Run with make 'run-env-mozdef -e ENV=my.env'
 ifneq ("$(wildcard $(ENV))","") #Check for existence of ENV
@@ -40,10 +33,6 @@ ifneq ("$(wildcard $(ENV))","") #Check for existence of ENV
 else
 	@echo $(ENV) not found.
 endif
-
-.PHONY: restart-cloudy-mozdef
-restart-cloudy-mozdef:
-	docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p $(NAME) restart
 
 .PHONY: test
 test: build-tests run-tests

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -255,6 +255,24 @@ Resources:
                 # This is the additional worker reserved for future use
                 OPTIONS_TASKEXCHANGE=${MozDefSQSQueueName}
               path: /opt/mozdef/docker/compose/cloudy_mozdef_mq_sns_sqs.env
+            - content: |
+                [Unit]
+                Description=Docker Compose container starter
+                After=docker.service network-online.target
+                Requires=docker.service network-online.target
+
+                [Service]
+                WorkingDirectory=/opt/mozdef
+                Type=oneshot
+                RemainAfterExit=yes
+
+                ExecStart=/bin/docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p mozdef up -d
+
+                ExecStop=/bin/docker-compose -f docker/compose/docker-compose-cloudy-mozdef.yml -p mozdef down
+
+                [Install]
+                WantedBy=multi-user.target
+              path: /etc/systemd/system/docker-compose.service
           runcmd:
             - echo RABBITMQ_PASSWORD=`python3 -c 'import secrets; s = secrets.token_hex(); print(s)'` > /opt/mozdef/docker/compose/rabbitmq.env
             - chmod --verbose 600 /opt/mozdef/docker/compose/rabbitmq.env
@@ -268,7 +286,9 @@ Resources:
             - grep "${EFSID}" /etc/fstab >/dev/null || echo "${EFSID}:/ ${EFSMountPoint} efs tls,_netdev" >> /etc/fstab
             - for i in 1 2 3 4 5 6; do mount --verbose --all --types efs defaults && break || sleep 15; done
             - cd /opt/mozdef && git pull origin master
-            - make -C /opt/mozdef -f /opt/mozdef/Makefile  run-cloudy-mozdef
+            - systemctl daemon-reload
+            - systemctl enable docker-compose
+            - systemctl start docker-compose
             - cd /opt/mozdef && docker-compose -f docker/compose/docker-compose.yml -p mozdef exec -T rabbitmq rabbitmqctl add_user mozdef \$RABBITMQ_PASSWORD
             - cd /opt/mozdef && docker-compose -f docker/compose/docker-compose.yml -p mozdef exec -T rabbitmq rabbitmqctl set_user_tags mozdef administrator
             - cd /opt/mozdef && docker-compose -f docker/compose/docker-compose.yml -p mozdef exec -T rabbitmq rabbitmqctl set_permissions -p / mozdef ".*" ".*" ".*"


### PR DESCRIPTION
This changes from launching docker containers with docker compose
via a make target to a systemd service.

This should ensure graceful shutdown of containers upon instance shutdown.
Previously containers were not shutting down gracefully causing a leftover
lock file for mongodb in the EFS filesystem

Related JIRA ticket [EIS-732](https://jira.mozilla.com/browse/EIS-732)