### PR TITLE
Use wildcard in indices for searching

### DIFF
--- a/alerts/lib/alerttask.py
+++ b/alerts/lib/alerttask.py
@@ -106,7 +106,10 @@ class AlertTask(Task):
         self._configureKombu()
         self._configureES()
 
-        self.event_indices = ['events', 'events-previous']
+        # We want to select all event indices
+        # and filter out the window based on timestamp
+        # from the search query
+        self.event_indices = ['events-*']
 
     def classname(self):
         return self.__class__.__name__

--- a/cron/syncAlertsToMongo.py
+++ b/cron/syncAlertsToMongo.py
@@ -26,7 +26,7 @@ def getESAlerts(es):
     # We use an ExistsMatch here just to satisfy the
     # requirements of a search query must have some "Matchers"
     search_query.add_must(ExistsMatch('summary'))
-    results = search_query.execute(es, indices=['alerts'], size=10000)
+    results = search_query.execute(es, indices=['alerts-*'], size=10000)
     return results
 
 

--- a/mozdef_util/mozdef_util/query_models/search_query.py
+++ b/mozdef_util/mozdef_util/query_models/search_query.py
@@ -46,7 +46,7 @@ class SearchQuery(object):
     def add_aggregation(self, input_obj):
         self.append_to_array(self.aggregation, input_obj)
 
-    def execute(self, elasticsearch_client, indices=['events', 'events-previous'], size=1000, request_timeout=30):
+    def execute(self, elasticsearch_client, indices=['events-*'], size=1000, request_timeout=30):
         if self.must == [] and self.must_not == [] and self.should == [] and self.aggregation == []:
             raise AttributeError('Must define a must, must_not, should query, or aggregation')
 

--- a/rest/plugins/logincounts.py
+++ b/rest/plugins/logincounts.py
@@ -80,7 +80,10 @@ class message(object):
         search_query.add_aggregation(Aggregation('details.success'))
         search_query.add_aggregation(Aggregation('details.username'))
 
-        results = search_query.execute(es_client, indices=['events','events-previous'])
+        # We want to select all event indices
+        # and filter out the window based on timestamp
+        # from the search query
+        results = search_query.execute(es_client, indices=['events-*'])
 
         # any usernames or words to ignore
         # especially useful if ES is analyzing the username field and breaking apart user@somewhere.com


### PR DESCRIPTION
Now that ES is more efficient with timestamped data, we can expand the search indices across all events-*, and all alerts-*. Previously, we were restricting our search window between 24 - 48 hours (events to events-previously).

We ran some benchmarks, and it turns out there isn't a very large performance hit when expanding to wildcards:
```
------------ benchmark: 2 tests -----------ons (2/2)
Name (time in ms)            Mean          
-------------------------------------------
test_events_weekly        90.7345 (1.0)    
test_events_wildcard     105.5318 (1.16)   
-------------------------------------------
```