### PR TITLE
adding details to eventname so this alert can fire.

### DIFF
--- a/alerts/cloudtrail_logging_disabled.py
+++ b/alerts/cloudtrail_logging_disabled.py
@@ -29,6 +29,6 @@ class AlertCloudtrailLoggingDisabled(AlertTask):
         tags = ['cloudtrail', 'aws', 'cloudtrailpagerduty']
         severity = 'CRITICAL'
 
-        summary = 'Cloudtrail Logging Disabled: ' + event['_source']['requestparameters']['name']
+        summary = 'Cloudtrail Logging Disabled: ' + event['_source']['details']['requestparameters']['name']
 
         return self.createAlertDict(summary, category, tags, [event], severity)

--- a/alerts/cloudtrail_logging_disabled.py
+++ b/alerts/cloudtrail_logging_disabled.py
@@ -15,7 +15,7 @@ class AlertCloudtrailLoggingDisabled(AlertTask):
 
         search_query.add_must([
             TermMatch('source', 'cloudtrail'),
-            TermMatch('eventname', 'StopLogging')
+            TermMatch('details.eventname', 'StopLogging')
         ])
 
         search_query.add_must_not(TermMatch('errorcode', 'AccessDenied'))

--- a/tests/alerts/test_cloudtrail_logging_disabled.py
+++ b/tests/alerts/test_cloudtrail_logging_disabled.py
@@ -11,10 +11,12 @@ class TestAlertCloudtrailLoggingDisabled(AlertTestSuite):
     # alert to trigger
     default_event = {
         "_source": {
-            "details.eventname": "StopLogging",
             "source": "cloudtrail",
-            "requestparameters": {
-                "name": "cloudtrail_example_name",
+            "details": {
+                "eventname": "StopLogging",
+                "requestparameters": {
+                    "name": "cloudtrail_example_name",
+                }
             }
         }
     }

--- a/tests/alerts/test_cloudtrail_logging_disabled.py
+++ b/tests/alerts/test_cloudtrail_logging_disabled.py
@@ -11,7 +11,7 @@ class TestAlertCloudtrailLoggingDisabled(AlertTestSuite):
     # alert to trigger
     default_event = {
         "_source": {
-            "eventname": "StopLogging",
+            "details.eventname": "StopLogging",
             "source": "cloudtrail",
             "requestparameters": {
                 "name": "cloudtrail_example_name",
@@ -59,7 +59,7 @@ class TestAlertCloudtrailLoggingDisabled(AlertTestSuite):
     )
 
     event = AlertTestSuite.create_event(default_event)
-    event['_source']['eventname'] = 'Badeventname'
+    event['_source']['details']['eventname'] = 'Badeventname'
     test_cases.append(
         NegativeAlertTestCase(
             description="Negative test case with bad eventName",


### PR DESCRIPTION
This event logs our query criteria as:

details.eventname: StopLogging

Adding the "details" to the term match should fix this.

Also updated alert unit test.


