### PR TITLE
Modify mozdef instance file for cloudy mozdef

### DIFF
--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -126,6 +126,8 @@ Resources:
                 # to use relative links to Kibana : https://github.com/mozilla/MozDef/pull/956
                 OPTIONS_METEOR_KIBANAURL=https://relative:9090/_plugin/kibana/
                 OPTIONS_METEOR_ROOTURL=https://${DomainName}
+                # Disable certain web ui features
+                OPTIONS_REMOVE_FEATURES=ipblocklist,fqdnblocklist,logincounts,globe
                 # See https://github.com/mozilla-iam/mozilla.oidc.accessproxy/blob/master/README.md#setup
                 # Future support will be added for cognito backed authentication.
                 client_id=${OIDCClientId}

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -172,9 +172,11 @@ Resources:
                 ALERTS = {
                     'bruteforce_ssh.AlertBruteforceSsh': {'schedule': crontab(minute='*/1')},
                     'unauth_ssh.AlertUnauthSSH': {'schedule': crontab(minute='*/1')},
+                    'get_watchlist.AlertWatchList': {'schedule': timedelta(minutes=1)},
                     'guard_duty_probe.AlertGuardDutyProbe': {'schedule': crontab(minute='*/1')},
                     'cloudtrail_logging_disabled.AlertCloudtrailLoggingDisabled': {'schedule': timedelta(minutes=1)},
-                    'cloudtrail_deadman.AlertCloudtrailDeadman': {'schedule': timedelta(hours=1)}
+                    'cloudtrail_public_bucket.AlertCloudtrailPublicBucket': {'schedule': timedelta(minutes=1)},
+                    'cloudtrail_deadman.AlertCloudtrailDeadman': {'schedule': timedelta(hours=1)},
                 }
 
                 ALERT_PLUGINS = [
@@ -273,6 +275,12 @@ Resources:
                 [Install]
                 WantedBy=multi-user.target
               path: /etc/systemd/system/docker-compose.service
+            - content: |
+                [options]
+                api_url = http://rest:8081/getwatchlist
+                jwt_secret = secret
+                use_auth = false
+              path: /opt/mozdef/docker/compose/mozdef_alerts/files/get_watchlist.conf
           runcmd:
             - echo RABBITMQ_PASSWORD=`python3 -c 'import secrets; s = secrets.token_hex(); print(s)'` > /opt/mozdef/docker/compose/rabbitmq.env
             - chmod --verbose 600 /opt/mozdef/docker/compose/rabbitmq.env


### PR DESCRIPTION
1. Enable cloudtrail alert
2. Enable watchlist alert with custom config file
3. Disable certain web ui features for cloudy mozdef instance

Depends on https://github.com/mozilla/MozDef/pull/1256