### PR TITLE
Basic auth password should be randomized

### DIFF
--- a/cloudy_mozdef/Makefile
+++ b/cloudy_mozdef/Makefile
@@ -21,8 +21,9 @@ S3_PROD_BUCKET_PATH	:= mozdef/cf
 S3_PROD_BUCKET_URI	:= s3://$(S3_PROD_BUCKET_NAME)/$(S3_PROD_BUCKET_PATH)
 S3_PROD_STACK_URI	:= https://s3-$(AWS_REGION).amazonaws.com/$(S3_PROD_BUCKET_NAME)/$(S3_PROD_BUCKET_PATH)/
 
-# OIDC_CLIENT_SECRET is set in an environment variable by running "source aws_parameters.sh"
+# OIDC_CLIENT_SECRET and other secrets are set in an environment variable by running "source aws_parameters.sh"
 OIDC_CLIENT_SECRET_PARAM_ARG := $(shell test -n "$(OIDC_CLIENT_SECRET)" && echo "ParameterKey=OIDCClientSecret,ParameterValue=$(OIDC_CLIENT_SECRET)")
+ALB_BASIC_AUTH_SECRET_PARAM_ARG := $(shell test -n "$(ALB_BASIC_AUTH_SECRET_PARAM_ARG)" && echo "ParameterKey=ALBBasicAuthSecret,ParameterValue=$(ALB_BASIC_AUTH_SECRET_PARAM_ARG)")
 
 .PHONY:all
 all:
@@ -45,6 +46,7 @@ create-dev-stack: test ## Create everything you need for a fresh new stack!
 	aws cloudformation create-stack --stack-name $(STACK_NAME) --template-url $(S3_DEV_STACK_URI)mozdef-parent.yml \
 	  --capabilities CAPABILITY_IAM \
 	  --parameters $(OIDC_CLIENT_SECRET_PARAM_ARG) \
+	               $(ALB_BASIC_AUTH_SECRET_PARAM_ARG) \
 	               $(DEV_STACK_PARAMS) \
 	  --output text
 
@@ -60,6 +62,7 @@ update-dev-stack: test ## Updates the nested stack on AWS
 	aws cloudformation update-stack --stack-name $(STACK_NAME) --template-url $(S3_DEV_STACK_URI)mozdef-parent.yml \
 	  --capabilities CAPABILITY_IAM \
 	  --parameters $(OIDC_CLIENT_SECRET_PARAM_ARG) \
+	               $(ALB_BASIC_AUTH_SECRET_PARAM_ARG) \
 	               $(DEV_STACK_PARAMS) \
 	  --output text
 

--- a/cloudy_mozdef/aws_parameters.example.json
+++ b/cloudy_mozdef/aws_parameters.example.json
@@ -43,5 +43,10 @@
     "ParameterKey": "OIDCClientSecret",
     "ParameterValue": "secret-value-goes-here",
     "UsePreviousValue": false
+  },
+  {
+    "ParameterKey": "ALBBasicAuthSecret",
+    "ParameterValue": "secret-value-goes-here",
+    "UsePreviousValue": false
   }
 ]

--- a/cloudy_mozdef/aws_parameters.example.sh
+++ b/cloudy_mozdef/aws_parameters.example.sh
@@ -1,1 +1,2 @@
 export OIDC_CLIENT_SECRET=secretgoeshere
+export ALB_BASIC_AUTH_SECRET=secretgoeshere

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -52,7 +52,7 @@ Parameters:
     Type: String
     Default: Unset
     ConstraintDescription: A valid URL
-    Description: "The url of the authorization endpoint found for your oidc provider generall found on (Example: https://auth.example.com/.well-known/openid-configuration)"
+    Description: "The URL of the authorization endpoint found for your OIDC provider generaly found on (Example: https://auth.example.com/.well-known/openid-configuration)"
   OIDCClientId:
     Type: String
     Default: Unset
@@ -86,9 +86,15 @@ Parameters:
   AlertQueueUrl:
     Type: String
     Description: The url of the alert queue kombu should use for taskExchange.
+  ALBBasicAuthSecret:
+    Type: String
+    Default: Unset
+    Description: Default basic authentication password, if enabled.
+    NoEcho: true
 Conditions:
   OIDCEnabledCondition:
     !Not [!Equals [!Ref OIDCClientId, Unset]]
+    !Equals [!Ref ALBBasicAuthSecret, Unset]]
   OIDCNotEnabledCondition:
     !Equals [!Ref OIDCClientId, Unset]
   SSLEnabledCondition:
@@ -166,6 +172,7 @@ Resources:
                 # Future support will be added for cognito backed authentication.
                 client_id=${OIDCClientId}
                 client_secret=${OIDCClientSecret}
+                basic_auth_secret=${ALBBasicAuthSecret}
                 backend=http://meteor:3000
                 redirect_uri_path=/redirect_uri
                 httpsredir=no

--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -27,6 +27,7 @@ Metadata:
         - OIDCIssuer
         - OIDCTokenEndpoint
         - OIDCUserInfoEndpoint
+        - ALBBasicAuthSecret
     ParameterLabels:
       VpcId:
         default: VPC ID
@@ -159,6 +160,7 @@ Resources:
         OIDCIssuer: !Ref OIDCIssuer
         OIDCTokenEndpoint: !Ref OIDCTokenEndpoint
         OIDCUserInfoEndpoint: !Ref OIDCUserInfoEndpoint
+        ALBBasicAuthSecret: !Ref ALBBasicAuthSecret
         CloudTrailSQSNotificationQueueName: !GetAtt MozDefCloudTrail.Outputs.CloudTrailSQSQueueName
         MozDefSQSQueueName: !GetAtt MozDefSQS.Outputs.SQSQueueName
         DomainName: !Ref DomainName

--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -54,6 +54,8 @@ Metadata:
         default: OIDC oauth token endpoint.
       OIDCUserInfoEndpoint:
         default: OIDC user info endpoint.
+      ALBBasicAuthSecret:
+        default: Default basic authentication password, if enabled.
 Parameters:
   VpcId:
     Type: AWS::EC2::VPC::Id

--- a/docker/compose/docker-compose-cloudy-mozdef.yml
+++ b/docker/compose/docker-compose-cloudy-mozdef.yml
@@ -8,7 +8,6 @@ services:
       options:
         max-file: "1"
         max-size: "10m"
-    command: ["/usr/bin/openresty", "-g", "daemon off;"]
     env_file:
       - cloudy_mozdef.env
     restart: always

--- a/docker/compose/mozdef_cognito_proxy/Dockerfile
+++ b/docker/compose/mozdef_cognito_proxy/Dockerfile
@@ -1,5 +1,7 @@
 FROM openresty/openresty:centos
-ADD docker/compose/mozdef_cognito_proxy/files/htpasswd.example /etc/nginx/htpasswd
-ADD docker/compose/mozdef_cognito_proxy/files/default.conf /etc/nginx/conf.d/default.conf
-ADD docker/compose/mozdef_cognito_proxy/files/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+ADD files/default.conf /etc/nginx/conf.d/default.conf
+ADD files/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+RUN touch /etc/nginx/htpasswd
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-jwt
+RUN yum install -y httpd-tools && yum clean all
+CMD bash -c "/usr/bin/htpasswd  -Bbc /etc/nginx/htpasswd mozdef $basic_auth_secret 2> /dev/null; /usr/bin/openresty -g 'daemon off;'"

--- a/docker/compose/mozdef_cognito_proxy/files/default.conf
+++ b/docker/compose/mozdef_cognito_proxy/files/default.conf
@@ -14,7 +14,7 @@ server {
         lua_need_request_body on;
         auth_basic_user_file /etc/nginx/htpasswd;
         set_by_lua_block $backend {return os.getenv("METEOR_BACKEND")}
-        set_by_lua_block $auth_basic_set { if os.getenv("OIDC_CLIENT_ID") == "Unset" then return "yes" else return "no" end }
+        set_by_lua_block $auth_basic_set { if os.getenv("basic_auth_secret") == "Unset" then return "no" else return "yes" end }
         set $auth_basic off;
         if ($auth_basic_set = yes) {
            set $auth_basic Restricted;

--- a/docker/compose/mozdef_cognito_proxy/files/htpasswd.example
+++ b/docker/compose/mozdef_cognito_proxy/files/htpasswd.example
@@ -1,1 +1,0 @@
-mozdef:$apr1$gXiYI6mD$lsgYLnKtsHWfQJep/aCnh.

--- a/docs/source/cloud_deployment.rst
+++ b/docs/source/cloud_deployment.rst
@@ -31,10 +31,10 @@ MozDef requires the following:
   at the IP address of the Application Load Balancer
 - An OIDC Provider with ClientID, ClientSecret, and Discovery URL
 
-  - Mozilla Uses Auth0 but you can use any OIDC provider you like: Shibboleth,
-    KeyCloak, AWS Cognito, Okta, Ping (etc)
+  - Mozilla uses Auth0 but you can use any OIDC provider you like: Shibboleth,
+    KeyCloak, AWS Cognito, Okta, Ping (etc.)
   - You will need to configure the redirect URI of ``/redirect_uri`` as allowed in
-    your OIDC provider
+    your OIDC provider configuration
 - An ACM Certificate in the deployment region for your DNS name
 - A VPC with three public subnets available.
 
@@ -49,8 +49,7 @@ MozDef requires the following:
 Supported Regions
 ------------------
 
-MozDef for AWS is currently only supported in us-west-2 but will onboard
-additional regions over time.
+MozDef for AWS is currently only supported in us-west-2 but additional regions will be added over time.
 
 
 Architecture


### PR DESCRIPTION
https://jira.mozilla.com/browse/EIS-970

> Currently in order to prototype I set the basic auth password for a user to be mozde:mozdef.  Let's randomize this and output it as a parameter that the user can get to in cloudformation console instead.


Currently testing this