### PR TITLE
Add commented out ports line for mongodb

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,54 +1,6 @@
 ---
 version: '3.7'
 services:
-  nginx:
-    image: mozdef/mozdef_nginx
-    build:
-      context: ../../
-      dockerfile: docker/compose/nginx/Dockerfile
-      cache_from:
-        - mozdef/mozdef_nginx
-        - mozdef_nginx:latest
-    restart: always
-    command: /usr/sbin/nginx
-    depends_on:
-      - kibana
-      - meteor
-    ports:
-      - 80:80
-      - 8080:8080
-      - 9090:9090
-      # - 8081:8081
-    networks:
-      - default
-  mongodb:
-    image: mozdef/mozdef_mongodb
-    build:
-      context: ../../
-      dockerfile: docker/compose/mongodb/Dockerfile
-      cache_from:
-        - mozdef/mozdef_mongodb
-        - mozdef_mongodb:latest
-    restart: always
-    command: /usr/bin/mongod --smallfiles --config /etc/mongod.conf
-    volumes:
-      - mongodb:/var/lib/mongo
-    networks:
-      - default
-  kibana:
-    image: mozdef/mozdef_kibana
-    build:
-      context: ../../
-      dockerfile: docker/compose/kibana/Dockerfile
-      cache_from:
-        - mozdef/mozdef_kibana
-        - mozdef_kibana:latest
-    restart: always
-    command: bin/kibana --elasticsearch=http://elasticsearch:9200
-    depends_on:
-      - elasticsearch
-    networks:
-      - default
   elasticsearch:
     image: mozdef/mozdef_elasticsearch
     build:
@@ -80,6 +32,56 @@ services:
     # ports:
     #   - 5672:5672
     #   - 15672:15672 # Admin interface
+    networks:
+      - default
+  mongodb:
+    image: mozdef/mozdef_mongodb
+    build:
+      context: ../../
+      dockerfile: docker/compose/mongodb/Dockerfile
+      cache_from:
+        - mozdef/mozdef_mongodb
+        - mozdef_mongodb:latest
+    restart: always
+    command: /usr/bin/mongod --smallfiles --config /etc/mongod.conf
+    volumes:
+      - mongodb:/var/lib/mongo
+    # ports:
+    #   - 3002:3002
+    networks:
+      - default
+  kibana:
+    image: mozdef/mozdef_kibana
+    build:
+      context: ../../
+      dockerfile: docker/compose/kibana/Dockerfile
+      cache_from:
+        - mozdef/mozdef_kibana
+        - mozdef_kibana:latest
+    restart: always
+    command: bin/kibana --elasticsearch=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+    networks:
+      - default
+  nginx:
+    image: mozdef/mozdef_nginx
+    build:
+      context: ../../
+      dockerfile: docker/compose/nginx/Dockerfile
+      cache_from:
+        - mozdef/mozdef_nginx
+        - mozdef_nginx:latest
+    restart: always
+    command: /usr/sbin/nginx
+    depends_on:
+      - kibana
+      - meteor
+    ports:
+      - 80:80
+      - 8080:8080
+      - 9090:9090
+      # - 8081:8081
     networks:
       - default
 


### PR DESCRIPTION
1. This adds a commented out ports line for mongodb container so a developer can easily uncomment to expose locally.
2. Reordered a couple services based on type of container