### PR TITLE
Ensure that geolite DB is fetched when MozDef launches

### DIFF
--- a/cron/update_geolite_db.py
+++ b/cron/update_geolite_db.py
@@ -49,6 +49,8 @@ def save_db_data(save_path, db_data):
 def main():
     logger.debug('Starting')
     logger.debug(options)
+    if options.only_update_if_absent and os.path.isfile(options.db_location):
+        return True
     db_data = fetch_db_data(options.db_download_location)
     save_db_data(options.db_location, db_data)
 
@@ -70,6 +72,9 @@ if __name__ == '__main__':
         dest='configfile',
         default=sys.argv[0].replace('.py', '.conf'),
         help="configuration file to use")
+    parser.add_option(
+        "-o", "--only-update-if-absent", action="store_true",
+        help="Only update the geolite DB if it's not present on disk")
     (options, args) = parser.parse_args()
     initConfig()
     initLogger(options)

--- a/cron/update_geolite_db.sh
+++ b/cron/update_geolite_db.sh
@@ -6,4 +6,4 @@
 # Copyright (c) 2017 Mozilla Corporation
 
 source  /opt/mozdef/envs/python/bin/activate
-/opt/mozdef/envs/mozdef/cron/update_geolite_db.py -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.conf
+/opt/mozdef/envs/mozdef/cron/update_geolite_db.py -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.conf "$@"

--- a/docker/compose/mozdef_cron/files/cron_entries.txt
+++ b/docker/compose/mozdef_cron/files/cron_entries.txt
@@ -7,3 +7,4 @@ BASH_ENV=/env
 0 0 * * * /opt/mozdef/envs/mozdef/cron/esMaint.sh
 0 8 * * * /opt/mozdef/envs/mozdef/cron/pruneES.sh
 0 0 * * * /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh
+@reboot /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh --only-update-if-absent


### PR DESCRIPTION
Adds conditional fetching behavior to only fetch if the geolite DB is absent from disk
Adds crontab entry to fetch if absent when crond launches
Relates to https://jira.mozilla.com/browse/EIS-1005