### PR TITLE
Fix geolite db missing issue

### DIFF
--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -78,8 +78,8 @@ Parameters:
     Description: The CIDR of IP addresses from which to allow inbound SSH connections
   DomainName:
     Type: String
-    Description: The fully qualified DNS name you will host CloudyMozDef at.
-    Default: cloudymozdef.security.allizom.org
+    Description: The fully qualified DNS name you will host MozDef at if you want to use a custom domain
+    Default: Unset
   ACMCertArn:
     Type: String
     Default: Unset

--- a/docker/compose/docker-compose-cloudy-mozdef.yml
+++ b/docker/compose/docker-compose-cloudy-mozdef.yml
@@ -223,7 +223,7 @@ services:
     env_file:
       - cloudy_mozdef.env
     restart: always
-    command: bash -c 'python esworker_eventtask.py -c esworker_eventtask.conf'
+    command: bash -c 'test -e /opt/mozdef/envs/mozdef/data/GeoLite2-City.mmdb && python esworker_eventtask.py -c esworker_eventtask.conf'
     scale: 1
     depends_on:
       - base
@@ -245,7 +245,7 @@ services:
       - cloudy_mozdef.env
       - cloudy_mozdef_mq_cloudtrail.env
     restart: always
-    command: bash -c 'python esworker_cloudtrail.py -c esworker_cloudtrail.conf'
+    command: bash -c 'test -e /opt/mozdef/envs/mozdef/data/GeoLite2-City.mmdb && python esworker_cloudtrail.py -c esworker_cloudtrail.conf'
     scale: 1
     depends_on:
       - base
@@ -267,7 +267,7 @@ services:
       - cloudy_mozdef.env
       - cloudy_mozdef_mq_sqs.env
     restart: always
-    command: bash -c 'python esworker_sqs.py -c esworker_sqs.conf'
+    command: bash -c 'test -e /opt/mozdef/envs/mozdef/data/GeoLite2-City.mmdb && python esworker_sqs.py -c esworker_sqs.conf'
     scale: 1
     depends_on:
       - base


### PR DESCRIPTION
This is meant to address https://jira.mozilla.com/browse/EIS-1005

This is a very simple hack to solve this one problem. This is an alternative to the larger solutions proposed in #1303 #1297 so that we can solve this one problem quickly. We still need to come up with a better solution, but just not today.

The notion is that that when these containers come up they'll test for the existence of the Geo IP data file in the docker shared volume. If it's absent the command should fail and the container should stop, then start again (since they're set to `restart: always`. Eventually once the `base` container runs and does the one time fetch, the worker containers should start working

This also clarifies that the `DomainName` parameter is optional. Andrew reports that the basic auth sites work just fine despite passing a domain name to meteor (via the `DomainName` parameter) that doesn't map to the site. If that is indeed true then we can just pass `Unset` to meteor. If that's not true, then we would need to conditionally handle the `Unset` value on the instance side to pass or not pass a domain name to meteor in the [`OPTIONS_METEOR_ROOTURL`](https://github.com/mozilla/MozDef/blob/9fa979337fb165a602f8ca609cb91af6d5f6e1aa/cloudy_mozdef/cloudformation/mozdef-instance.yml#L165) environment variable.
