### PR TITLE
Replace "unset" with empty string

### DIFF
--- a/cloudy_mozdef/Makefile
+++ b/cloudy_mozdef/Makefile
@@ -47,8 +47,8 @@ safety-checks:
 	@echo "Making sure you have an environment variable OIDC_CLIENT_SECRET set."
 	@test -n "$(OIDC_CLIENT_SECRET_PARAM_ARG)" -a -n "$(OIDC_CLIENT_ID)" -o -z "$(OIDC_CLIENT_SECRET_PARAM_ARG)" -a -z "$(OIDC_CLIENT_ID)"
 	@echo "Making sure you have either OIDC_CLIENT_ID or ALB_BASIC_AUTH_SECRET set."
-	# If both are equal then you're either leaking the secret, or, most likely, both are equal to string "Unset"
-	# which is unsafe (as it would effectively give you a basic auth password of string "Unset")
+	# If both are equal then you're either leaking the secret, or, most likely, both are equal to string ""
+	# which is unsafe (as it would effectively give you a basic auth password of string "")
 	$(call eq, $(OIDC_CLIENT_ID), $(ALB_BASIC_AUTH_SECRET_PARAM_ARG))
 
 .PHONY: create-dev-stack

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -33,7 +33,7 @@ Parameters:
   MozDefLoadBalancerSecurityGroupId:
     Type: AWS::EC2::SecurityGroup::Id
     Description: The security group to apply to the EC2 instance
-  MozDefACMCertArn:
+  ACMCertArn:
     Type: String
     Description: The arn of your pre-issued certificate for ssl termination.
   ESURL:
@@ -151,11 +151,11 @@ Conditions:
   OIDCNotEnabledCondition:
     !Equals [!Ref OIDCClientId, '']
   SSLEnabledCondition:
-    !And [!Not [!Equals [!Ref MozDefACMCertArn, '']], !Equals [!Ref OIDCClientId, '']]
+    !And [!Not [!Equals [!Ref ACMCertArn, '']], !Equals [!Ref OIDCClientId, '']]
   SSLNotEnabledCondition:
-    !And [!Equals [!Ref MozDefACMCertArn, ''], !Equals [!Ref OIDCClientId, '']]
+    !And [!Equals [!Ref ACMCertArn, ''], !Equals [!Ref OIDCClientId, '']]
   SSLEnabledWithOidcCondition:
-    !And [!Not [!Equals [!Ref MozDefACMCertArn, '']], !Not [!Equals [!Ref OIDCClientId, '']]]
+    !And [!Not [!Equals [!Ref ACMCertArn, '']], !Not [!Equals [!Ref OIDCClientId, '']]]
 Resources:
   MozDefElasticLoadBalancingV2TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -431,7 +431,7 @@ Resources:
     Condition: SSLEnabledCondition
     Properties:
       Certificates:
-        - CertificateArn: !Ref MozDefACMCertArn
+        - CertificateArn: !Ref ACMCertArn
       DefaultActions:
       - Type: forward
         TargetGroupArn:
@@ -458,7 +458,7 @@ Resources:
     Condition: SSLEnabledCondition
     Properties:
       Certificates:
-        - CertificateArn: !Ref MozDefACMCertArn
+        - CertificateArn: !Ref ACMCertArn
       DefaultActions:
       - Type: forward
         TargetGroupArn:
@@ -519,7 +519,7 @@ Resources:
     Condition: SSLEnabledWithOidcCondition
     Properties:
       Certificates:
-        - CertificateArn: !Ref MozDefACMCertArn
+        - CertificateArn: !Ref ACMCertArn
       DefaultActions:
       - Type: authenticate-oidc
         AuthenticateOidcConfig:
@@ -547,7 +547,7 @@ Resources:
     Condition: SSLEnabledWithOidcCondition
     Properties:
       Certificates:
-        - CertificateArn: !Ref MozDefACMCertArn
+        - CertificateArn: !Ref ACMCertArn
       DefaultActions:
       - Type: authenticate-oidc
         AuthenticateOidcConfig:

--- a/cloudy_mozdef/cloudformation/mozdef-instance.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-instance.yml
@@ -50,29 +50,29 @@ Parameters:
     Default: https://kibana.example.com/
   OIDCAuthorizationEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     ConstraintDescription: A valid URL
     Description: "The URL of the authorization endpoint found for your OIDC provider generaly found on (Example: https://auth.example.com/.well-known/openid-configuration)"
   OIDCClientId:
     Type: String
-    Default: Unset
+    Default: ''
     Description: The client ID that your OIDC provider issues you for your Mozdef instance.
   OIDCClientSecret:
     Type: String
-    Default: Unset
+    Default: ''
     Description: The secret that your OIDC provider issues you for your Mozdef instance.
     NoEcho: true
   OIDCIssuer:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   OIDCTokenEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   OIDCUserInfoEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   CloudTrailSQSNotificationQueueName:
     Type: String
@@ -88,20 +88,74 @@ Parameters:
     Description: The url of the alert queue kombu should use for taskExchange.
   ALBBasicAuthSecret:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Default basic authentication password, if enabled.
     NoEcho: true
+Rules:
+  ALBBasicAuthOnly:
+    RuleCondition: !Not [ !Equals [ !Ref 'ALBBasicAuthSecret', '' ] ]
+    Assertions:
+    - Assert:
+        !EachMemberEquals
+        - - !Ref 'OIDCAuthorizationEndpoint'
+          - !Ref 'OIDCClientId'
+          - !Ref 'OIDCClientSecret'
+          - !Ref 'OIDCIssuer'
+          - !Ref 'OIDCTokenEndpoint'
+          - !Ref 'OIDCUserInfoEndpoint'
+        - ''
+      AssertDescription: >
+        If you set an ALBBasicAuthSecret indicating you wish to use HTTP Basic
+        Auth for authentication, you must leave all OIDC attributes blank
+  OIDCHasAllRequiredParameters:
+    RuleCondition:
+      !Or
+      - !Not [ !Equals [ !Ref 'OIDCAuthorizationEndpoint', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCClientSecret', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCIssuer', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCTokenEndpoint', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCUserInfoEndpoint', '' ] ]
+    Assertions:
+    - Assert:
+        !And
+        - !Not [ !Equals [ !Ref 'OIDCAuthorizationEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCClientSecret', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCIssuer', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCTokenEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCUserInfoEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'ACMCertArn', '' ] ]
+      AssertDescription: >
+        If you set any OIDC parameter indicating you wish to use OIDC for
+        authentication, you must set all six OIDC parameters, [
+        OIDCAuthorizationEndpoint, OIDCClientId, OIDCClientSecret, OIDCIssuer,
+        OIDCTokenEndpoint, OIDCUserInfoEndpoint] as well as an ACM Certificate
+        in the ACMCertArn parameter
+  SomeAuthHasBeenConfigured:
+    Assertions:
+    - Assert:
+        !Or
+        - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+        - !Not [ !Equals [ !Ref 'ALBBasicAuthSecret', '' ] ]
+      AssertDescription: >
+        You must choose either to use HTTP Basic Auth or OIDC for authentication.
+        To choose HTTP Basic Auth you must set an ALBBasicAuthSecret. To choose
+        OIDC you must set all six OIDC parameters, [OIDCAuthorizationEndpoint,
+        OIDCClientId, OIDCClientSecret, OIDCIssuer, OIDCTokenEndpoint,
+        OIDCUserInfoEndpoint] as well as an ACM Certificate in the ACMCertArn
+        parameter.
 Conditions:
   OIDCEnabledCondition:
-    !Not [!Equals [!Ref OIDCClientId, Unset]]
+    !Not [!Equals [!Ref OIDCClientId, '']]
   OIDCNotEnabledCondition:
-    !Equals [!Ref OIDCClientId, Unset]
+    !Equals [!Ref OIDCClientId, '']
   SSLEnabledCondition:
-    !And [!Not [!Equals [!Ref MozDefACMCertArn, Unset]], !Equals [!Ref OIDCClientId, Unset]]
+    !And [!Not [!Equals [!Ref MozDefACMCertArn, '']], !Equals [!Ref OIDCClientId, '']]
   SSLNotEnabledCondition:
-    !And [!Equals [!Ref MozDefACMCertArn, Unset], !Equals [!Ref OIDCClientId, Unset]]
+    !And [!Equals [!Ref MozDefACMCertArn, ''], !Equals [!Ref OIDCClientId, '']]
   SSLEnabledWithOidcCondition:
-    !And [!Not [!Equals [!Ref MozDefACMCertArn, Unset]], !Not [!Equals [!Ref OIDCClientId, Unset]]]
+    !And [!Not [!Equals [!Ref MozDefACMCertArn, '']], !Not [!Equals [!Ref OIDCClientId, '']]]
 Resources:
   MozDefElasticLoadBalancingV2TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup

--- a/cloudy_mozdef/cloudformation/mozdef-parent-reinforce.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent-reinforce.yml
@@ -221,7 +221,7 @@ Resources:
         EFSID: !GetAtt MozDefEFS.Outputs.EFSID
         MozDefSecurityGroupId: !GetAtt MozDefSecurityGroups.Outputs.MozDefSecurityGroupId
         MozDefLoadBalancerSecurityGroupId: !GetAtt MozDefSecurityGroups.Outputs.MozDefLoadBalancerSecurityGroupId
-        MozDefACMCertArn: !Ref ACMCertArn
+        ACMCertArn: !Ref ACMCertArn
         ESURL: !GetAtt MozDefES.Outputs.ElasticsearchURL
         KibanaURL: !GetAtt MozDefES.Outputs.ElasticsearchKibanaURL
         KibanaDomainOnlyURL: !GetAtt MozDefES.Outputs.ElasticsearchDomainOnlyURL

--- a/cloudy_mozdef/cloudformation/mozdef-parent-reinforce.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent-reinforce.yml
@@ -14,7 +14,7 @@ Metadata:
       Parameters:
         - ACMCertArn
     - Label:
-        default: OIDC Configuration (optional)  If not set this will use basic auth.
+        default: Authentication
       Parameters:
         - OIDCAuthorizationEndpoint
         - OIDCClientId
@@ -22,6 +22,7 @@ Metadata:
         - OIDCIssuer
         - OIDCTokenEndpoint
         - OIDCUserInfoEndpoint
+        - ALBBasicAuthSecret
     - Label:
         default: Experimental Features
       Parameters:
@@ -49,6 +50,8 @@ Metadata:
         default: OIDC oauth token endpoint.
       OIDCUserInfoEndpoint:
         default: OIDC user info endpoint.
+      ALBBasicAuthSecret:
+        default: Default basic authentication password, if enabled.
       LeakCredentialSNSArn: Arn of the SNS topic to post admin creds to.
 Parameters:
   InstanceType:
@@ -65,49 +68,103 @@ Parameters:
     Description: The CIDR of IP addresses from which to allow inbound SSH connections
   DomainName:
     Type: String
-    Description: The fully qualified DNS name you will host CloudyMozDef at.
-    Default: cloudymozdef.security.allizom.org
+    Description: The fully qualified DNS name you will host MozDef at if you want to use a custom domain. Optional.
+    Default: ''
   ACMCertArn:
     Type: String
-    Default: Unset
-    Description: "The ARN of your pre-issued ACM cert. (Example: arn:aws:acm:us-west-2:123456789012:certificate/abcdef01-2345-6789-abcd-ef0123456789)"
+    Default: ''
+    Description: "The ARN of your pre-issued ACM cert. Required if OIDC is being used. (Example: arn:aws:acm:us-west-2:123456789012:certificate/abcdef01-2345-6789-abcd-ef0123456789)"
   OIDCAuthorizationEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     ConstraintDescription: A valid URL
     Description: "The url of the authorization endpoint found for your oidc provider generall found on (Example: https://auth.example.com/.well-known/openid-configuration)"
   OIDCClientId:
     Type: String
-    Default: Unset
+    Default: ''
     Description: The client ID that your OIDC provider issues you for your Mozdef instance.
   OIDCClientSecret:
     Type: String
-    Default: Unset
+    Default: ''
     Description: The secret that your OIDC provider issues you for your Mozdef instance.
     NoEcho: true
   OIDCIssuer:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   OIDCTokenEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   OIDCUserInfoEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   LeakCredentialSNSArn:
     Type: String
     Description: The arn of the sns topic to post a credential back to from the account.  Do not use unless you are deploying this for reinforce workshop.  This will attack the MozDef account.
   ALBBasicAuthSecret:
     Type: String
-    Default: Unset
+    Default: ''
     Description: The secret that you use to authenticate to the MozDef instance using HTTP Basic Authentication.
     NoEcho: true
+Rules:
+  ALBBasicAuthOnly:
+    RuleCondition: !Not [ !Equals [ !Ref 'ALBBasicAuthSecret', '' ] ]
+    Assertions:
+    - Assert:
+        !EachMemberEquals
+        - - !Ref 'OIDCAuthorizationEndpoint'
+          - !Ref 'OIDCClientId'
+          - !Ref 'OIDCClientSecret'
+          - !Ref 'OIDCIssuer'
+          - !Ref 'OIDCTokenEndpoint'
+          - !Ref 'OIDCUserInfoEndpoint'
+        - ''
+      AssertDescription: >
+        If you set an ALBBasicAuthSecret indicating you wish to use HTTP Basic
+        Auth for authentication, you must leave all OIDC attributes blank
+  OIDCHasAllRequiredParameters:
+    RuleCondition:
+      !Or
+      - !Not [ !Equals [ !Ref 'OIDCAuthorizationEndpoint', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCClientSecret', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCIssuer', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCTokenEndpoint', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCUserInfoEndpoint', '' ] ]
+    Assertions:
+    - Assert:
+        !And
+        - !Not [ !Equals [ !Ref 'OIDCAuthorizationEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCClientSecret', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCIssuer', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCTokenEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCUserInfoEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'ACMCertArn', '' ] ]
+      AssertDescription: >
+        If you set any OIDC parameter indicating you wish to use OIDC for
+        authentication, you must set all six OIDC parameters, [
+        OIDCAuthorizationEndpoint, OIDCClientId, OIDCClientSecret, OIDCIssuer,
+        OIDCTokenEndpoint, OIDCUserInfoEndpoint] as well as an ACM Certificate
+        in the ACMCertArn parameter
+  SomeAuthHasBeenConfigured:
+    Assertions:
+    - Assert:
+        !Or
+        - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+        - !Not [ !Equals [ !Ref 'ALBBasicAuthSecret', '' ] ]
+      AssertDescription: >
+        You must choose either to use HTTP Basic Auth or OIDC for authentication.
+        To choose HTTP Basic Auth you must set an ALBBasicAuthSecret. To choose
+        OIDC you must set all six OIDC parameters, [OIDCAuthorizationEndpoint,
+        OIDCClientId, OIDCClientSecret, OIDCIssuer, OIDCTokenEndpoint,
+        OIDCUserInfoEndpoint] as well as an ACM Certificate in the ACMCertArn
+        parameter.
 # A RegionMap of AMI IDs is required by AWS Marketplace  https://docs.aws.amazon.com/marketplace/latest/userguide/cloudformation.html#aws-cloudformation-template-preparation
 # INSERT MAPPING HERE : This template does not work in this state. The mapping is replaced with a working AWS region to AMI ID mapping as well as a variable map with the S3TemplateLocationPrefix by cloudy_mozdef/ci/publish_versioned_templates. The resulting functioning CloudFormation template is uploaded to S3 for the version being built.
-Conditions: 
+Conditions:
   LeakACredential: !Not [!Equals [!Ref LeakCredentialSNSArn, ""]]
 Resources:
   LeakedCredentials:
@@ -299,7 +356,7 @@ Resources:
   NumberOfSubnets:
     Type: AWS::CloudFormation::CustomResource
     Properties:
-      Array: 
+      Array:
         - !GetAtt MozDefVPC.Outputs.Subnet1
         - !GetAtt MozDefVPC.Outputs.Subnet2
         - !GetAtt MozDefVPC.Outputs.Subnet3

--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -209,7 +209,7 @@ Resources:
         EFSID: !GetAtt MozDefEFS.Outputs.EFSID
         MozDefSecurityGroupId: !GetAtt MozDefSecurityGroups.Outputs.MozDefSecurityGroupId
         MozDefLoadBalancerSecurityGroupId: !GetAtt MozDefSecurityGroups.Outputs.MozDefLoadBalancerSecurityGroupId
-        MozDefACMCertArn: !Ref ACMCertArn
+        ACMCertArn: !Ref ACMCertArn
         ESURL: !GetAtt MozDefES.Outputs.ElasticsearchURL
         KibanaURL: !GetAtt MozDefES.Outputs.ElasticsearchKibanaURL
         KibanaDomainOnlyURL: !GetAtt MozDefES.Outputs.ElasticsearchDomainOnlyURL

--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -116,13 +116,6 @@ Parameters:
     Description: The secret that you use to authenticate to the MozDef instance using HTTP Basic Authentication.
     NoEcho: true
 Rules:
-  SubnetsInVPC:
-    Assertions:
-    - Assert:
-        !EachMemberIn
-        - !ValueOfAll [ 'AWS::EC2::Subnet::Id', 'VpcId' ]
-        - !RefAll 'AWS::EC2::VPC::Id'
-      AssertDescription: All subnets must in the VPC
   ALBBasicAuthOnly:
     RuleCondition: !Not [ !Equals [ !Ref 'ALBBasicAuthSecret', '' ] ]
     Assertions:

--- a/cloudy_mozdef/cloudformation/mozdef-parent.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-parent.yml
@@ -19,7 +19,7 @@ Metadata:
       Parameters:
         - ACMCertArn
     - Label:
-        default: OIDC Configuration (optional)  If not set this will use basic auth.
+        default: Authentication
       Parameters:
         - OIDCAuthorizationEndpoint
         - OIDCClientId
@@ -78,43 +78,104 @@ Parameters:
     Description: The CIDR of IP addresses from which to allow inbound SSH connections
   DomainName:
     Type: String
-    Description: The fully qualified DNS name you will host MozDef at if you want to use a custom domain
-    Default: Unset
+    Description: The fully qualified DNS name you will host MozDef at if you want to use a custom domain. Optional.
+    Default: ''
   ACMCertArn:
     Type: String
-    Default: Unset
-    Description: "The ARN of your pre-issued ACM cert. (Example: arn:aws:acm:us-west-2:123456789012:certificate/abcdef01-2345-6789-abcd-ef0123456789)"
+    Default: ''
+    Description: "The ARN of your pre-issued ACM cert. Required if OIDC is being used. (Example: arn:aws:acm:us-west-2:123456789012:certificate/abcdef01-2345-6789-abcd-ef0123456789)"
   OIDCAuthorizationEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     ConstraintDescription: A valid URL
     Description: "The url of the authorization endpoint found for your oidc provider generall found on (Example: https://auth.example.com/.well-known/openid-configuration)"
   OIDCClientId:
     Type: String
-    Default: Unset
+    Default: ''
     Description: The client ID that your OIDC provider issues you for your Mozdef instance.
   OIDCClientSecret:
     Type: String
-    Default: Unset
+    Default: ''
     Description: The secret that your OIDC provider issues you for your Mozdef instance.
     NoEcho: true
   OIDCIssuer:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   OIDCTokenEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   OIDCUserInfoEndpoint:
     Type: String
-    Default: Unset
+    Default: ''
     Description: Generally can be found at the .well-known endpoint for your provider.
   ALBBasicAuthSecret:
     Type: String
-    Default: Unset
+    Default: ''
     Description: The secret that you use to authenticate to the MozDef instance using HTTP Basic Authentication.
     NoEcho: true
+Rules:
+  SubnetsInVPC:
+    Assertions:
+    - Assert:
+        !EachMemberIn
+        - !ValueOfAll [ 'AWS::EC2::Subnet::Id', 'VpcId' ]
+        - !RefAll 'AWS::EC2::VPC::Id'
+      AssertDescription: All subnets must in the VPC
+  ALBBasicAuthOnly:
+    RuleCondition: !Not [ !Equals [ !Ref 'ALBBasicAuthSecret', '' ] ]
+    Assertions:
+    - Assert:
+        !EachMemberEquals
+        - - !Ref 'OIDCAuthorizationEndpoint'
+          - !Ref 'OIDCClientId'
+          - !Ref 'OIDCClientSecret'
+          - !Ref 'OIDCIssuer'
+          - !Ref 'OIDCTokenEndpoint'
+          - !Ref 'OIDCUserInfoEndpoint'
+        - ''
+      AssertDescription: >
+        If you set an ALBBasicAuthSecret indicating you wish to use HTTP Basic
+        Auth for authentication, you must leave all OIDC attributes blank
+  OIDCHasAllRequiredParameters:
+    RuleCondition:
+      !Or
+      - !Not [ !Equals [ !Ref 'OIDCAuthorizationEndpoint', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCClientSecret', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCIssuer', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCTokenEndpoint', '' ] ]
+      - !Not [ !Equals [ !Ref 'OIDCUserInfoEndpoint', '' ] ]
+    Assertions:
+    - Assert:
+        !And
+        - !Not [ !Equals [ !Ref 'OIDCAuthorizationEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCClientSecret', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCIssuer', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCTokenEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'OIDCUserInfoEndpoint', '' ] ]
+        - !Not [ !Equals [ !Ref 'ACMCertArn', '' ] ]
+      AssertDescription: >
+        If you set any OIDC parameter indicating you wish to use OIDC for
+        authentication, you must set all six OIDC parameters, [
+        OIDCAuthorizationEndpoint, OIDCClientId, OIDCClientSecret, OIDCIssuer,
+        OIDCTokenEndpoint, OIDCUserInfoEndpoint] as well as an ACM Certificate
+        in the ACMCertArn parameter
+  SomeAuthHasBeenConfigured:
+    Assertions:
+    - Assert:
+        !Or
+        - !Not [ !Equals [ !Ref 'OIDCClientId', '' ] ]
+        - !Not [ !Equals [ !Ref 'ALBBasicAuthSecret', '' ] ]
+      AssertDescription: >
+        You must choose either to use HTTP Basic Auth or OIDC for authentication.
+        To choose HTTP Basic Auth you must set an ALBBasicAuthSecret. To choose
+        OIDC you must set all six OIDC parameters, [OIDCAuthorizationEndpoint,
+        OIDCClientId, OIDCClientSecret, OIDCIssuer, OIDCTokenEndpoint,
+        OIDCUserInfoEndpoint] as well as an ACM Certificate in the ACMCertArn
+        parameter.
 # A RegionMap of AMI IDs is required by AWS Marketplace  https://docs.aws.amazon.com/marketplace/latest/userguide/cloudformation.html#aws-cloudformation-template-preparation
 # INSERT MAPPING HERE : This template does not work in this state. The mapping is replaced with a working AWS region to AMI ID mapping as well as a variable map with the S3TemplateLocationPrefix by cloudy_mozdef/ci/publish_versioned_templates. The resulting functioning CloudFormation template is uploaded to S3 for the version being built.
 Resources:

--- a/docker/compose/mozdef_cognito_proxy/files/default.conf
+++ b/docker/compose/mozdef_cognito_proxy/files/default.conf
@@ -14,14 +14,14 @@ server {
         lua_need_request_body on;
         auth_basic_user_file /etc/nginx/htpasswd;
         set_by_lua_block $backend {return os.getenv("METEOR_BACKEND")}
-        set_by_lua_block $auth_basic_set { if os.getenv("basic_auth_secret") == "Unset" then return "no" else return "yes" end }
+        set_by_lua_block $auth_basic_set { if os.getenv("basic_auth_secret") == "" then return "no" else return "yes" end }
         set $auth_basic off;
         if ($auth_basic_set = yes) {
            set $auth_basic Restricted;
         }
 
         set_by_lua_block $user {
-          if os.getenv("OIDC_CLIENT_ID") == "Unset" then
+          if os.getenv("OIDC_CLIENT_ID") == "" then
             ngx.log(ngx.NOTICE, 'OIDC authentication is not in use.  Logging in as sample user.')
             return "mozdefuser@sample.com"
           else
@@ -67,14 +67,14 @@ server {
         lua_need_request_body on;
         set_by_lua_block $backend {return os.getenv("ESBACKEND")}
         auth_basic_user_file /etc/nginx/htpasswd;
-        set_by_lua_block $auth_basic_set { if os.getenv("OIDC_CLIENT_ID") == "Unset" then return "yes" else return "no" end }
+        set_by_lua_block $auth_basic_set { if os.getenv("OIDC_CLIENT_ID") == "" then return "yes" else return "no" end }
         set $auth_basic off;
         if ($auth_basic_set = yes) {
            set $auth_basic Restricted;
         }
 
         set_by_lua_block $user {
-          if os.getenv("OIDC_CLIENT_ID") == "Unset" then
+          if os.getenv("OIDC_CLIENT_ID") == "" then
             return "mozdefuser@sample.com"
           else
             local resp = {headers=nil, body=nil}


### PR DESCRIPTION
Clarify that "unset" isn't a reserved word
Use an empty string as a default to make it easier to understand
Add Rules which validate
* that the user is either choosing basic auth or OIDC but not both.
* that all OIDC parameters are filled out if choosing OIDC.
* that ACM cert is filled out if choosing OIDC

I've tested login to basicauth over http
* basicauth prompt works
* SSL is disabled

I've tested login to OIDC over https
* OIDC prompt works and doesn't ask for basic auth
* SSL works