### PR TITLE
Removing restore script functionality as it isn't needed/used

### DIFF
--- a/cron/backup.conf
+++ b/cron/backup.conf
@@ -1,7 +1,5 @@
 [options]
 esservers=http://localhost:9200
-aws_access_key_id = <add_aws_access_key_id>
-aws_secret_access_key = <add_aws_secret_access_key>
 aws_bucket = <add_s3_bucket_name>
 backup_indices = <add_backup_indices>
 backup_dobackup = 1,1,1,1,1,1,1,1

--- a/cron/backupSnapshot.py
+++ b/cron/backupSnapshot.py
@@ -16,18 +16,14 @@
 # options.aws_bucket/elasticsearch/YYYY-MM/servername/indices/indexname
 
 import sys
-import os
 from datetime import datetime
 from datetime import timedelta
 from datetime import date
 from configlib import getConfig, OptionParser
 import calendar
 import socket
-import boto
-import boto.s3
 import requests
 import json
-from os.path import expanduser
 from mozdef_util.utilities.logger import logger
 
 
@@ -39,10 +35,6 @@ def main():
     }
     try:
         esserver = options.esservers[0]
-        s3 = boto.connect_s3(
-            aws_access_key_id=options.aws_access_key_id,
-            aws_secret_access_key=options.aws_secret_access_key
-        )
         idate = date.strftime(datetime.utcnow() - timedelta(days=1), '%Y%m%d')
         bucketdate = date.strftime(datetime.utcnow() - timedelta(days=1), '%Y-%m')
         hostname = socket.gethostname()
@@ -86,32 +78,6 @@ def main():
                 else:
                     logger.debug('snapshot %s finished' % index_to_snapshot)
 
-                # create a restore script
-                # referencing the latest snapshot
-                localpath = '%s/%s-restore.sh' % (expanduser("~"), index)
-
-                with open(localpath, 'w') as f:
-                    logger.debug('Writing %s' % localpath)
-                    f.write("""
-#!/bin/bash
-
-echo -n "Restoring the snapshot..."
-curl -s -XPOST "%s/_snapshot/s3backup/%s-%s/_restore?wait_for_completion=true"
-
-echo "DONE!"
-                    """ % (esserver, index_to_snapshot, epoch))
-
-                # upload the restore script
-                bucket = s3.get_bucket(options.aws_bucket)
-                key = bucket.new_key('elasticsearch/%s/%s/%s-%s-%s-restore.sh' % (
-                    bucketdate, hostname, index, idate, epoch))
-                key.set_contents_from_filename(localpath)
-
-                # removing local file
-                os.remove(localpath)
-
-    except boto.exception.NoAuthHandlerFound:
-        logger.error("No auth handler found, check your credentials")
     except Exception as e:
         logger.error("Unhandled exception, terminating: %r" % e)
 
@@ -158,17 +124,6 @@ def initConfig():
         'backup_pruning',
         '20,0,0',
         options.configfile).split(',')
-    )
-    # aws credentials to use to send files to s3
-    options.aws_access_key_id = getConfig(
-        'aws_access_key_id',
-        '',
-        options.configfile
-    )
-    options.aws_secret_access_key = getConfig(
-        'aws_secret_access_key',
-        '',
-        options.configfile
     )
     options.aws_bucket = getConfig(
         'aws_bucket',


### PR DESCRIPTION
- Removes non-working restore script generation
- Removes the need to upload the unused script to s3
- Removes the need to store aws creds in code as these will be handled via encrypted keystore now.