### PR TITLE
Add config option to suppress slack bot welcome message

### DIFF
--- a/bot/slack/mozdefbot.py
+++ b/bot/slack/mozdefbot.py
@@ -160,6 +160,9 @@ def init_config():
     # mqack=True sets persistant delivery, False sets transient delivery
     options.mq_ack = get_config('mqack', True, options.configfile)
 
+    # wether or not the bot should send a welcome message upon connecting
+    options.notify_welcome = get_config('notify_welcome', True, options.configfile)
+
 
 if __name__ == "__main__":
     parser = OptionParser()
@@ -170,7 +173,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
     init_config()
 
-    bot = SlackBot(options.slack_token, options.channels, options.name)
+    bot = SlackBot(options.slack_token, options.channels, options.name, options.notify_welcome)
     monitor_alerts_thread = Thread(target=consume_alerts, args=[bot])
     monitor_alerts_thread.daemon = True
     monitor_alerts_thread.start()

--- a/bot/slack/slack_bot.py
+++ b/bot/slack/slack_bot.py
@@ -20,10 +20,11 @@ greetings = [
 
 
 class SlackBot():
-    def __init__(self, api_key, channels, bot_name):
+    def __init__(self, api_key, channels, bot_name, notify_welcome):
         self.slack_client = SlackClient(api_key)
         self.channels = channels
         self.bot_name = bot_name
+        self.notify_welcome = notify_welcome
         self.load_commands()
 
     def load_commands(self):
@@ -36,7 +37,8 @@ class SlackBot():
     def run(self):
         if self.slack_client.rtm_connect():
             logger.info("Bot connected to slack")
-            self.post_welcome_message(random.choice(greetings))
+            if self.notify_welcome:
+                self.post_welcome_message(random.choice(greetings))
             self.listen_for_messages()
         else:
             logger.error("Unable to connect to slack")


### PR DESCRIPTION
Slack sometimes pushes out updates to their infrastructure, which causes our slackbot to post messages during reconnection. 

This will allow users to turn off this welcome message during reconnection.