### PR TITLE
Improve Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ run-tests-resources:  ## Just run the external resources required for tests
 .PHONY: run-test
 run-test: run-tests
 
-.PHONY: run-test
+.PHONY: run-tests
 run-tests: run-tests-resources  ## Just run the tests (no build/get). Use `make TEST_CASE=tests/...` for specific tests only
 	docker run -it --rm mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && flake8 --config .flake8 ./"
 	docker run -it --rm --network=test-mozdef_default mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && py.test --delete_indexes --delete_queues $(TEST_CASE)"

--- a/docker/compose/elasticsearch/Dockerfile
+++ b/docker/compose/elasticsearch/Dockerfile
@@ -7,11 +7,17 @@ ENV ES_JAVA_VERSION 1.8.0
 
 
 RUN \
+  gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
+  rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
+  rpmkeys --import https://packages.elastic.co/GPG-KEY-elasticsearch && \
+  rpm -qi gpg-pubkey-d88e42b4-52371eca | $gpg | grep 0xD27D666CD88E42B4 && \
   yum install -y java-$ES_JAVA_VERSION && \
   mkdir -p /opt/mozdef/envs && \
-  curl -s -L https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.rpm -o elasticsearch.rpm && \
-  rpm -i elasticsearch.rpm && \
-  yum clean all
+  curl --silent --location https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ES_VERSION.rpm -o elasticsearch.rpm && \
+  rpm --install elasticsearch.rpm && \
+  yum clean all && \
+  rm -rf /var/cache/yum
 
 USER elasticsearch
 

--- a/docker/compose/kibana/Dockerfile
+++ b/docker/compose/kibana/Dockerfile
@@ -6,11 +6,12 @@ LABEL maintainer="mozdef@mozilla.com"
 ENV KIBANA_VERSION 6.8.0
 
 RUN \
-    curl -s -L https://artifacts.elastic.co/downloads/kibana/kibana-$KIBANA_VERSION-linux-x86_64.tar.gz | tar -C / -xz && \
-    cd /kibana-$KIBANA_VERSION-linux-x86_64
+  mkdir /kibana && \
+  curl --silent --location https://artifacts.elastic.co/downloads/kibana/kibana-$KIBANA_VERSION-linux-x86_64.tar.gz \
+    | tar --extract --gzip --strip 1 --directory /kibana
 
-COPY docker/compose/kibana/files/kibana.yml /kibana-$KIBANA_VERSION-linux-x86_64/config/kibana.yml
+COPY docker/compose/kibana/files/kibana.yml /kibana/config/kibana.yml
 
-WORKDIR /kibana-$KIBANA_VERSION-linux-x86_64
+WORKDIR /kibana
 
 EXPOSE 5601

--- a/docker/compose/mongodb/Dockerfile
+++ b/docker/compose/mongodb/Dockerfile
@@ -5,14 +5,20 @@ LABEL maintainer="mozdef@mozilla.com"
 ENV MONGO_VERSION 3.4
 
 RUN \
-  echo -e "[mongodb-org-$MONGO_VERSION]\nname=MongoDB Repository\nbaseurl=https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/$MONGO_VERSION/x86_64/\ngpgcheck=1\nenabled=1\ngpgkey=https://www.mongodb.org/static/pgp/server-$MONGO_VERSION.asc" > /etc/yum.repos.d/mongodb.repo && \
+  echo -e "[mongodb-org-$MONGO_VERSION]\n\
+name=MongoDB Repository\n\
+baseurl=https://repo.mongodb.org/yum/redhat/\$releasever/mongodb-org/$MONGO_VERSION/x86_64/\n\
+gpgcheck=1\n\
+enabled=1\n\
+gpgkey=https://www.mongodb.org/static/pgp/server-$MONGO_VERSION.asc" > /etc/yum.repos.d/mongodb.repo && \
   gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
   rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
   rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
   rpmkeys --import https://www.mongodb.org/static/pgp/server-3.4.asc && \
   rpm -qi gpg-pubkey-a15703c6 | $gpg | grep 0xBC711F9BA15703C6 && \
   yum install -y mongodb-org && \
-  yum clean all
+  yum clean all && \
+  rm -rf /var/cache/yum
 
 COPY docker/compose/mongodb/files/mongod.conf /etc/mongod.conf
 

--- a/docker/compose/mozdef_alertactions/Dockerfile
+++ b/docker/compose/mozdef_alertactions/Dockerfile
@@ -2,10 +2,9 @@ FROM mozdef/mozdef_base
 
 LABEL maintainer="mozdef@mozilla.com"
 
-COPY alerts /opt/mozdef/envs/mozdef/alerts
-COPY docker/compose/mozdef_alertactions/files/alert_actions_worker.conf /opt/mozdef/envs/mozdef/alerts/alert_actions_worker.conf
-COPY docker/compose/mozdef_alerts/files/config.py /opt/mozdef/envs/mozdef/alerts/lib/config.py
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/alerts
+COPY --chown=mozdef:mozdef alerts /opt/mozdef/envs/mozdef/alerts
+COPY --chown=mozdef:mozdef docker/compose/mozdef_alertactions/files/alert_actions_worker.conf /opt/mozdef/envs/mozdef/alerts/alert_actions_worker.conf
+COPY --chown=mozdef:mozdef docker/compose/mozdef_alerts/files/config.py /opt/mozdef/envs/mozdef/alerts/lib/config.py
 
 WORKDIR /opt/mozdef/envs/mozdef/alerts
 

--- a/docker/compose/mozdef_alerts/Dockerfile
+++ b/docker/compose/mozdef_alerts/Dockerfile
@@ -2,11 +2,9 @@ FROM mozdef/mozdef_base
 
 LABEL maintainer="mozdef@mozilla.com"
 
-COPY alerts /opt/mozdef/envs/mozdef/alerts
-COPY docker/compose/mozdef_alerts/files/config.py /opt/mozdef/envs/mozdef/alerts/lib/
-COPY docker/compose/mozdef_alerts/files/get_watchlist.conf /opt/mozdef/envs/mozdef/alerts/get_watchlist.conf
-
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/alerts
+COPY --chown=mozdef:mozdef alerts /opt/mozdef/envs/mozdef/alerts
+COPY --chown=mozdef:mozdef docker/compose/mozdef_alerts/files/config.py /opt/mozdef/envs/mozdef/alerts/lib/
+COPY --chown=mozdef:mozdef docker/compose/mozdef_alerts/files/get_watchlist.conf /opt/mozdef/envs/mozdef/alerts/get_watchlist.conf
 
 WORKDIR /opt/mozdef/envs/mozdef/alerts
 

--- a/docker/compose/mozdef_base/Dockerfile
+++ b/docker/compose/mozdef_base/Dockerfile
@@ -5,54 +5,55 @@ LABEL maintainer="mozdef@mozilla.com"
 ENV TZ UTC
 
 RUN \
+  gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
+  rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
+  rpmkeys --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7 && \
+  rpm -qi gpg-pubkey-352c64e5 | $gpg | grep 0x6A2FAEA2352C64E5 && \
   yum makecache fast && \
   yum install -y epel-release && \
   yum install -y \
-                  glibc-devel \
-                  gcc \
-                  libstdc++ \
-                  libffi-devel \
-                  zlib-devel \
-                  libcurl-devel \
-                  openssl \
-                  openssl-devel \
-                  git \
-                  make && \
-  useradd -ms /bin/bash -d /opt/mozdef -m mozdef && \
-  mkdir /opt/mozdef/envs && \
-  cd /opt/mozdef && \
-  yum install -y python36 \
-                    python36-devel \
-                    python36-pip && \
+     glibc-devel \
+     gcc \
+     libstdc++ \
+     libffi-devel \
+     zlib-devel \
+     libcurl-devel \
+     openssl \
+     openssl-devel \
+     git \
+     make \
+     python36 \
+     python36-devel \
+     python36-pip && \
   yum clean all && \
+  rm -rf /var/cache/yum && \
+  useradd --create-home --shell /bin/bash --home-dir /opt/mozdef mozdef && \
   pip3 install virtualenv && \
-  mkdir /opt/mozdef/envs/mozdef && \
-  mkdir /opt/mozdef/envs/mozdef/cron
+  install --owner mozdef --group mozdef --directory /opt/mozdef/envs /opt/mozdef/envs/mozdef /opt/mozdef/envs/mozdef/cron
 
 # Force pycurl to understand we prefer nss backend
 # Pycurl with ssl support is required by kombu in order to use SQS
 ENV PYCURL_SSL_LIBRARY=nss
 
 # Create python virtual environment and install dependencies
-COPY requirements.txt /opt/mozdef/envs/mozdef/requirements.txt
+COPY --chown=mozdef:mozdef requirements.txt /opt/mozdef/envs/mozdef/requirements.txt
 
-COPY cron/update_geolite_db.py /opt/mozdef/envs/mozdef/cron/update_geolite_db.py
-COPY cron/update_geolite_db.conf /opt/mozdef/envs/mozdef/cron/update_geolite_db.conf
-COPY cron/update_geolite_db.sh /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh
+COPY --chown=mozdef:mozdef cron/update_geolite_db.py /opt/mozdef/envs/mozdef/cron/update_geolite_db.py
+COPY --chown=mozdef:mozdef cron/update_geolite_db.conf /opt/mozdef/envs/mozdef/cron/update_geolite_db.conf
+COPY --chown=mozdef:mozdef cron/update_geolite_db.sh /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh
 
-COPY mozdef_util /opt/mozdef/envs/mozdef/mozdef_util
-
-RUN chown -R mozdef:mozdef /opt/mozdef/
+COPY --chown=mozdef:mozdef mozdef_util /opt/mozdef/envs/mozdef/mozdef_util
 
 USER mozdef
 RUN \
   virtualenv -p /usr/bin/python3.6 /opt/mozdef/envs/python && \
   source /opt/mozdef/envs/python/bin/activate && \
-  pip install -r /opt/mozdef/envs/mozdef/requirements.txt && \
+  pip install --requirement /opt/mozdef/envs/mozdef/requirements.txt && \
   cd /opt/mozdef/envs/mozdef/mozdef_util && \
-  pip install -e .
+  pip install --editable . && \
+  mkdir /opt/mozdef/envs/mozdef/data
 
-RUN mkdir /opt/mozdef/envs/mozdef/data
 
 WORKDIR /opt/mozdef/envs/mozdef
 

--- a/docker/compose/mozdef_bootstrap/Dockerfile
+++ b/docker/compose/mozdef_bootstrap/Dockerfile
@@ -2,16 +2,14 @@ FROM mozdef/mozdef_base
 
 LABEL maintainer="mozdef@mozilla.com"
 
-RUN mkdir -p /opt/mozdef/envs/mozdef/docker/conf
+RUN install --owner mozdef --group mozdef --directory /opt/mozdef/envs/mozdef/docker /opt/mozdef/envs/mozdef/docker/conf
 
-COPY cron/mozdefStateDefaultMappingTemplate.json /opt/mozdef/envs/mozdef/cron/mozdefStateDefaultMappingTemplate.json
-COPY cron/defaultMappingTemplate.json /opt/mozdef/envs/mozdef/cron/defaultMappingTemplate.json
-COPY docker/compose/mozdef_cron/files/backup.conf /opt/mozdef/envs/mozdef/cron/backup.conf
-COPY docker/compose/mozdef_bootstrap/files/initial_setup.py /opt/mozdef/envs/mozdef/initial_setup.py
-COPY docker/compose/mozdef_bootstrap/files/index_mappings /opt/mozdef/envs/mozdef/index_mappings
-COPY docker/compose/mozdef_bootstrap/files/resources /opt/mozdef/envs/mozdef/resources
-
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/
+COPY --chown=mozdef:mozdef cron/mozdefStateDefaultMappingTemplate.json /opt/mozdef/envs/mozdef/cron/mozdefStateDefaultMappingTemplate.json
+COPY --chown=mozdef:mozdef cron/defaultMappingTemplate.json /opt/mozdef/envs/mozdef/cron/defaultMappingTemplate.json
+COPY --chown=mozdef:mozdef docker/compose/mozdef_cron/files/backup.conf /opt/mozdef/envs/mozdef/cron/backup.conf
+COPY --chown=mozdef:mozdef docker/compose/mozdef_bootstrap/files/initial_setup.py /opt/mozdef/envs/mozdef/initial_setup.py
+COPY --chown=mozdef:mozdef docker/compose/mozdef_bootstrap/files/index_mappings /opt/mozdef/envs/mozdef/index_mappings
+COPY --chown=mozdef:mozdef docker/compose/mozdef_bootstrap/files/resources /opt/mozdef/envs/mozdef/resources
 
 WORKDIR /opt/mozdef/envs/mozdef
 

--- a/docker/compose/mozdef_bot/Dockerfile
+++ b/docker/compose/mozdef_bot/Dockerfile
@@ -4,10 +4,10 @@ LABEL maintainer="mozdef@mozilla.com"
 
 ARG BOT_TYPE
 
-COPY bot/$BOT_TYPE /opt/mozdef/envs/mozdef/bot/$BOT_TYPE
-COPY docker/compose/mozdef_bot/files/mozdefbot.conf /opt/mozdef/envs/mozdef/bot/$BOT_TYPE/mozdefbot.conf
+RUN install --owner mozdef --group mozdef --directory /opt/mozdef/envs/mozdef/bot
 
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/bot/$BOT_TYPE
+COPY --chown=mozdef:mozdef bot/$BOT_TYPE /opt/mozdef/envs/mozdef/bot/$BOT_TYPE
+COPY --chown=mozdef:mozdef docker/compose/mozdef_bot/files/mozdefbot.conf /opt/mozdef/envs/mozdef/bot/$BOT_TYPE/mozdefbot.conf
 
 WORKDIR /opt/mozdef/envs/mozdef/bot/$BOT_TYPE
 

--- a/docker/compose/mozdef_cognito_proxy/Dockerfile
+++ b/docker/compose/mozdef_cognito_proxy/Dockerfile
@@ -3,5 +3,5 @@ ADD docker/compose/mozdef_cognito_proxy/files/default.conf /etc/nginx/conf.d/def
 ADD docker/compose/mozdef_cognito_proxy/files/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
 RUN touch /etc/nginx/htpasswd
 RUN /usr/local/openresty/luajit/bin/luarocks install lua-resty-jwt
-RUN yum install -y httpd-tools && yum clean all
+RUN yum install -y httpd-tools && yum clean all && rm -rf /var/cache/yum
 CMD bash -c "/usr/bin/htpasswd  -bc /etc/nginx/htpasswd mozdef $basic_auth_secret 2> /dev/null; /usr/bin/openresty -g 'daemon off;'"

--- a/docker/compose/mozdef_cron/Dockerfile
+++ b/docker/compose/mozdef_cron/Dockerfile
@@ -5,20 +5,19 @@ LABEL maintainer="mozdef@mozilla.com"
 RUN \
   yum makecache fast && \
   yum install -y cronie && \
-  yum clean all
+  yum clean all && \
+  rm -rf /var/cache/yum
 
-COPY cron /opt/mozdef/envs/mozdef/cron
+COPY --chown=mozdef:mozdef cron /opt/mozdef/envs/mozdef/cron
 COPY docker/compose/mozdef_cron/files/cron_entries.txt /cron_entries.txt
 
 # Copy config files for crons
-COPY docker/compose/mozdef_cron/files/backup.conf /opt/mozdef/envs/mozdef/cron/backup.conf
-COPY docker/compose/mozdef_cron/files/collectAttackers.conf /opt/mozdef/envs/mozdef/cron/collectAttackers.conf
-COPY docker/compose/mozdef_cron/files/eventStats.conf /opt/mozdef/envs/mozdef/cron/eventStats.conf
-COPY docker/compose/mozdef_cron/files/healthAndStatus.conf /opt/mozdef/envs/mozdef/cron/healthAndStatus.conf
-COPY docker/compose/mozdef_cron/files/healthToMongo.conf /opt/mozdef/envs/mozdef/cron/healthToMongo.conf
-COPY docker/compose/mozdef_cron/files/syncAlertsToMongo.conf /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.conf
-
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/cron
+COPY --chown=mozdef:mozdef docker/compose/mozdef_cron/files/backup.conf /opt/mozdef/envs/mozdef/cron/backup.conf
+COPY --chown=mozdef:mozdef docker/compose/mozdef_cron/files/collectAttackers.conf /opt/mozdef/envs/mozdef/cron/collectAttackers.conf
+COPY --chown=mozdef:mozdef docker/compose/mozdef_cron/files/eventStats.conf /opt/mozdef/envs/mozdef/cron/eventStats.conf
+COPY --chown=mozdef:mozdef docker/compose/mozdef_cron/files/healthAndStatus.conf /opt/mozdef/envs/mozdef/cron/healthAndStatus.conf
+COPY --chown=mozdef:mozdef docker/compose/mozdef_cron/files/healthToMongo.conf /opt/mozdef/envs/mozdef/cron/healthToMongo.conf
+COPY --chown=mozdef:mozdef docker/compose/mozdef_cron/files/syncAlertsToMongo.conf /opt/mozdef/envs/mozdef/cron/syncAlertsToMongo.conf
 
 # https://stackoverflow.com/a/48651061/168874
 COPY docker/compose/mozdef_cron/files/launch_cron /launch_cron

--- a/docker/compose/mozdef_loginput/Dockerfile
+++ b/docker/compose/mozdef_loginput/Dockerfile
@@ -2,10 +2,8 @@ FROM mozdef/mozdef_base
 
 LABEL maintainer="mozdef@mozilla.com"
 
-COPY loginput /opt/mozdef/envs/mozdef/loginput
-COPY docker/compose/mozdef_loginput/files/index.conf /opt/mozdef/envs/mozdef/loginput/index.conf
-
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/loginput
+COPY --chown=mozdef:mozdef loginput /opt/mozdef/envs/mozdef/loginput
+COPY --chown=mozdef:mozdef docker/compose/mozdef_loginput/files/index.conf /opt/mozdef/envs/mozdef/loginput/index.conf
 
 EXPOSE 8080
 

--- a/docker/compose/mozdef_meteor/Dockerfile
+++ b/docker/compose/mozdef_meteor/Dockerfile
@@ -11,46 +11,52 @@ ENV PORT=3000
 
 ARG METEOR_BUILD='YES'
 
-RUN \
-  useradd -ms /bin/bash -d /opt/mozdef -m mozdef && \
-  mkdir -p /opt/mozdef/envs/mozdef && \
-  cd /opt/mozdef && \
-  chown -R mozdef:mozdef /opt/mozdef && \
-  curl -sL https://rpm.nodesource.com/setup_8.x | bash - && \
-  yum makecache fast && \
-  yum install -y \
-                wget \
-                make \
-                glibc-devel \
-                gcc \
-                gcc-c++ \
-                libstdc++ \
-                libffi-devel \
-                zlib-devel \
-                nodejs && \
-  yum clean all && \
-  mkdir /opt/mozdef/meteor && \
-  curl -sL -o /opt/mozdef/meteor.tar.gz https://static-meteor.netdna-ssl.com/packages-bootstrap/$METEOR_VERSION/meteor-bootstrap-os.linux.x86_64.tar.gz && \
-  tar -xzf /opt/mozdef/meteor.tar.gz -C /opt/mozdef/meteor && \
-  mv /opt/mozdef/meteor/.meteor /opt/mozdef && \
-  rm -r /opt/mozdef/meteor && \
-  cp /opt/mozdef/.meteor/packages/meteor-tool/*/mt-os.linux.x86_64/scripts/admin/launch-meteor /usr/bin/meteor
+# Ignore warnings like 'No such file or directory for /usr/share/info/*.info.gz"
+# https://bugzilla.redhat.com/show_bug.cgi?id=516757
 
-COPY meteor /opt/mozdef/envs/mozdef/meteor
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/meteor
+RUN \
+  useradd --create-home --shell /bin/bash --home-dir /opt/mozdef mozdef && \
+  cd /opt/mozdef && \
+  gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
+  rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
+  yum makecache fast && \
+  yum install -y which && \
+  curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && \
+  rpmkeys --import /etc/pki/rpm-gpg/NODESOURCE-GPG-SIGNING-KEY-EL && \
+  rpm -qi gpg-pubkey-34fa74dd | $gpg | grep 0x5DDBE8D434FA74DD && \
+  yum install -y \
+     make \
+     glibc-devel \
+     gcc \
+     gcc-c++ \
+     libstdc++ \
+     libffi-devel \
+     zlib-devel \
+     nodejs && \
+  yum clean all && \
+  rm -rf /var/cache/yum && \
+  echo "Downloading meteor" && \
+  curl --silent --location https://static-meteor.netdna-ssl.com/packages-bootstrap/$METEOR_VERSION/meteor-bootstrap-os.linux.x86_64.tar.gz \
+    | tar --extract --gzip --directory /opt/mozdef .meteor && \
+  ln --symbolic /opt/mozdef/.meteor/packages/meteor-tool/*/mt-os.linux.x86_64/scripts/admin/launch-meteor /usr/bin/meteor && \
+  install --owner mozdef --group mozdef --directory /opt/mozdef/envs /opt/mozdef/envs/mozdef
+
+COPY --chown=mozdef:mozdef meteor /opt/mozdef/envs/mozdef/meteor
 
 USER mozdef
-RUN mkdir -p /opt/mozdef/envs/meteor/mozdef
 
 # build meteor runtime if asked, if set to NO, only create the dir created above to mount to do live development
-RUN if [ "${METEOR_BUILD}" = "YES" ]; then \
-        cd /opt/mozdef/envs/mozdef/meteor && \
-        meteor npm install && \
-        echo "Starting meteor build" && \
-        time meteor build --server localhost:3002 --directory /opt/mozdef/envs/meteor/mozdef && \
-        cp -r /opt/mozdef/envs/mozdef/meteor/node_modules /opt/mozdef/envs/meteor/mozdef/node_modules &&\
-        cd /opt/mozdef/envs/meteor/mozdef/bundle/programs/server && \
-        npm install ;\
+RUN \
+  if [ "${METEOR_BUILD}" = "YES" ]; then \
+    mkdir -p /opt/mozdef/envs/meteor/mozdef && \
+    cd /opt/mozdef/envs/mozdef/meteor && \
+    meteor npm install && \
+    echo "Starting meteor build" && \
+    time meteor build --server localhost:3002 --directory /opt/mozdef/envs/meteor/mozdef && \
+    ln --symbolic /opt/mozdef/envs/meteor/mozdef/node_modules /opt/mozdef/envs/mozdef/meteor/node_modules && \
+    cd /opt/mozdef/envs/meteor/mozdef/bundle/programs/server && \
+    npm install ;\
   fi
 
 WORKDIR /opt/mozdef/envs/meteor/mozdef

--- a/docker/compose/mozdef_mq_worker/Dockerfile
+++ b/docker/compose/mozdef_mq_worker/Dockerfile
@@ -2,10 +2,8 @@ FROM mozdef/mozdef_base
 
 LABEL maintainer="mozdef@mozilla.com"
 
-COPY mq /opt/mozdef/envs/mozdef/mq
-COPY docker/compose/mozdef_mq_worker/files/*.conf /opt/mozdef/envs/mozdef/mq/
-
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/mq
+COPY --chown=mozdef:mozdef mq /opt/mozdef/envs/mozdef/mq
+COPY --chown=mozdef:mozdef docker/compose/mozdef_mq_worker/files/*.conf /opt/mozdef/envs/mozdef/mq/
 
 WORKDIR /opt/mozdef/envs/mozdef/mq
 

--- a/docker/compose/mozdef_rest/Dockerfile
+++ b/docker/compose/mozdef_rest/Dockerfile
@@ -2,10 +2,8 @@ FROM mozdef/mozdef_base
 
 LABEL maintainer="mozdef@mozilla.com"
 
-COPY rest /opt/mozdef/envs/mozdef/rest
-COPY docker/compose/mozdef_rest/files/index.conf /opt/mozdef/envs/mozdef/rest/index.conf
-
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/rest
+COPY --chown=mozdef:mozdef rest /opt/mozdef/envs/mozdef/rest
+COPY --chown=mozdef:mozdef docker/compose/mozdef_rest/files/index.conf /opt/mozdef/envs/mozdef/rest/index.conf
 
 EXPOSE 8081
 

--- a/docker/compose/mozdef_sampledata/Dockerfile
+++ b/docker/compose/mozdef_sampledata/Dockerfile
@@ -2,11 +2,9 @@ FROM mozdef/mozdef_base
 
 LABEL maintainer="mozdef@mozilla.com"
 
-RUN mkdir -p /opt/mozdef/envs/mozdef/examples
-COPY ./examples /opt/mozdef/envs/mozdef/examples
+COPY --chown=mozdef:mozdef ./examples /opt/mozdef/envs/mozdef/examples
 
-COPY docker/compose/mozdef_sampledata/files/sampleData2MozDef.conf /opt/mozdef/envs/mozdef/examples/demo/sampleData2MozDef.conf
-RUN chown -R mozdef:mozdef /opt/mozdef/envs/mozdef/examples
+COPY --chown=mozdef:mozdef docker/compose/mozdef_sampledata/files/sampleData2MozDef.conf /opt/mozdef/envs/mozdef/examples/demo/sampleData2MozDef.conf
 RUN chmod u+rwx /opt/mozdef/envs/mozdef/examples/demo/sampleevents.sh
 
 WORKDIR /opt/mozdef/envs/mozdef/examples/demo

--- a/docker/compose/mozdef_syslog/Dockerfile
+++ b/docker/compose/mozdef_syslog/Dockerfile
@@ -14,7 +14,8 @@ RUN \
   rpm -qi gpg-pubkey-352c64e5 | $gpg | grep 0x6A2FAEA2352C64E5 && \
   yum install -y epel-release && \
   yum install -y syslog-ng.x86_64 syslog-ng-json && \
-  yum clean all
+  yum clean all && \
+  rm -rf /var/cache/yum
 
 COPY docker/compose/mozdef_syslog/files/syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 

--- a/docker/compose/rabbitmq/Dockerfile
+++ b/docker/compose/rabbitmq/Dockerfile
@@ -8,10 +8,13 @@ COPY docker/compose/rabbitmq/files/rabbitmq-server.repo /etc/yum.repos.d/rabbitm
 COPY docker/compose/rabbitmq/files/erlang.repo /etc/yum.repos.d/erlang.repo
 
 RUN \
-  yum -q makecache -y fast && \
-  yum install -y epel-release && \
+  gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong" && \
+  rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+  rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5 && \
+  yum --quiet makecache -y fast && \
   yum install -y rabbitmq-server-$RABBITMQ_VERSION && \
-  yum clean all
+  yum clean all && \
+  rm -rf /var/cache/yum
 
 COPY docker/compose/rabbitmq/files/rabbitmq.config /etc/rabbitmq/
 COPY docker/compose/rabbitmq/files/enabled_plugins /etc/rabbitmq/


### PR DESCRIPTION
* Change pattern of a final recursive chown to instead intentionally setting
  the owner and group in the COPY commands. This should avoid a layer that
  touches all previously copied files
* Add checks for yum repo signing key fingerprint
* Expand some command line arguments to long form so it's easily
  understandably by the reader without having to lookup the man page
* Add removal of yum cache to reduce docker image size
* Change kibana WORKDIR to a fixed and simple value of /kibana
* Cleanup long lines to be more readable
* Use symbolic links instead of internal file copies to reduce docker image size
* Standardize on indents of two spaces