### PR TITLE
Remove virtualenv requirement from MozDef and tox from mozdef_util

### DIFF
--- a/mozdef_util/setup.py
+++ b/mozdef_util/setup.py
@@ -20,7 +20,6 @@ requirements = [
     'wheel>=0.32.1',
     'watchdog>=0.9.0',
     'flake8>=3.5.0',
-    'tox>=3.5.2',
     'coverage>=4.5.1',
     'Sphinx>=1.8.1',
     'twine>=1.12.1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,5 @@ tzlocal==1.4
 uritemplate==0.6
 urllib3==1.24.3
 uwsgi==2.0.17.1
-virtualenv==1.11.4
 tldextract==2.2.0
 websocket-client==0.44.0


### PR DESCRIPTION
virtualenv isn't actually used within MozDef and so isn't needed
tox should only be part of the dev requirements for mozdef_util as it's used in testing, not the setup.py requirements
Fixes #1370