### PR TITLE
Bugfix AWS CodeBuild settings

### DIFF
--- a/cloudy_mozdef/ci/deploy
+++ b/cloudy_mozdef/ci/deploy
@@ -21,6 +21,10 @@ echo "  Event : ${CODEBUILD_WEBHOOK_EVENT}"
 echo "  Head Ref : ${CODEBUILD_WEBHOOK_HEAD_REF}"
 echo "  Trigger : ${CODEBUILD_WEBHOOK_TRIGGER}"
 
+if [ -z "${CODEBUILD_WEBHOOK_TRIGGER}" ]; then
+  echo "CODEBUILD_WEBHOOK_TRIGGER is unset, likely because this build was retried. Retry build isn't supported. Exiting"
+  exit 1
+fi
 echo "Codebuild is ubuntu 14.04. Installing packer in order to compensate. Someone should build a CI docker container \;)."
 wget -nv https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip
 unzip packer_1.3.5_linux_amd64.zip -d /usr/bin

--- a/cloudy_mozdef/cloudformation/mozdef-cicd-codebuild.yml
+++ b/cloudy_mozdef/cloudformation/mozdef-cicd-codebuild.yml
@@ -1,5 +1,9 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: CodeBuild CI/CD Job to build on commit
+Description: MozDef CodeBuild CI/CD Job and IAM role
+Parameters:
+  CodeBuildProjectName:
+    Type: String
+    Description: The name of the CodeBuild project to create. Project names can't be modified once the project is created
 Mappings:
   VariableMap:
     Variables:
@@ -42,12 +46,12 @@ Resources:
                 Action:
                   - s3:PutObject*
                   - s3:GetObject*
-                Resource: !Join [ '', [ 'arn:aws:s3::', !FindInMap [ 'VariableMap', 'Variables', 'S3BucketToPublishCloudFormationTemplatesTo' ], '/*' ] ]
+                Resource: !Join [ '', [ 'arn:aws:s3:::', !FindInMap [ 'VariableMap', 'Variables', 'S3BucketToPublishCloudFormationTemplatesTo' ], '/*' ] ]
               - Sid: ListS3BucketContents
                 Effect: Allow
                 Action:
                   - s3:ListBucket*
-                Resource: !Join [ '', [ 'arn:aws:s3::', !FindInMap [ 'VariableMap', 'Variables', 'S3BucketToPublishCloudFormationTemplatesTo' ] ] ]
+                Resource: !Join [ '', [ 'arn:aws:s3:::', !FindInMap [ 'VariableMap', 'Variables', 'S3BucketToPublishCloudFormationTemplatesTo' ] ] ]
               - Sid: CreatePackerEC2Instance
                 Effect: Allow
                 Action:
@@ -79,24 +83,21 @@ Resources:
                   - ec2:DescribeImageAttribute
                   - ec2:DescribeSubnets
                 Resource: '*'
-              - Sid: ReadSSMParameters
+              - Sid: ReadSecrets
                 Effect: Allow
                 Action: ssm:GetParameter
                 Resource: arn:aws:ssm:*:*:parameter/mozdef/ci/*
-              # I think these are vestigial, created by the CodeBuild UI.
-              # Also they're not even the right resource path since they contain "/aws/codebuild/" but the actual LogGroup that CodeBuild writes to doesn't
-              # e.g. arn:aws:logs:us-west-2:371522382791:log-group:MozDefCI:*
-#              - Sid: NotSure1
-#                Effect: Allow
-#                Action:
-#                  - logs:CreateLogGroup
-#                  - logs:CreateLogStream
-#                  - logs:PutLogEvents
-#                Resource:
-#                  - !Join [ ':', [ 'arn:aws:logs', !Ref 'AWS::Region', !Ref 'AWS::AccountId', 'log-group:/aws/codebuild/mozdef' ] ]
-#                  - !Join [ ':', [ 'arn:aws:logs', !Ref 'AWS::Region', !Ref 'AWS::AccountId', 'log-group:/aws/codebuild/mozdef:*' ] ]
-#                  - !Join [ ':', [ 'arn:aws:logs', !Ref 'AWS::Region', !Ref 'AWS::AccountId', 'log-group:/aws/codebuild/MozDefCI' ] ]
-#                  - !Join [ ':', [ 'arn:aws:logs', !Ref 'AWS::Region', !Ref 'AWS::AccountId', 'log-group:/aws/codebuild/MozDefCI:*' ] ]
+              - Sid: CloudWatchLogGroup
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                Resource: !Join [ ':', [ 'arn:aws:logs', !Ref 'AWS::Region', !Ref 'AWS::AccountId', 'log-group', !FindInMap [ 'VariableMap', 'Variables', 'CloudWatchLogGroupName' ] ] ]
+              - Sid: CloudWatchLogStream
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Join [ ':', [ 'arn:aws:logs', !Ref 'AWS::Region', !Ref 'AWS::AccountId', 'log-group', !FindInMap [ 'VariableMap', 'Variables', 'CloudWatchLogGroupName' ], 'log-stream:*' ] ]
               - Sid: NotSure2
                 Action:
                   - s3:PutObject
@@ -110,8 +111,8 @@ Resources:
   CodeBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
-      Name: mozdef
-      Description: Builds MozDef AMI, dockers containers,  and runs test suite. Owner is Andrew Krug.
+      Name: !Ref CodeBuildProjectName
+      Description: Builds the MozDef AMI, the MozDef Docker containers and shares the AMIs with AWS Marketplace.
       BadgeEnabled: True
       ServiceRole: !GetAtt CodeBuildServiceRole.Arn
       Artifacts:
@@ -120,22 +121,21 @@ Resources:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_MEDIUM
         Image: aws/codebuild/docker:18.09.0-1.7.0
+        PrivilegedMode: true  # Required for docker
       Source:
         Type: GITHUB
-        # Auth:  # This information is for the AWS CodeBuild console's use only. Your code should not get or set Auth directly.
-        # SourceIdentifier:  # Not sure what this should be yet
         BuildSpec: cloudy_mozdef/buildspec.yml
-        Location: https://github.com/mozilla/MozDef
+        Location: https://github.com/mozilla/MozDef.git
         ReportBuildStatus: True
       Triggers:
         Webhook: true
         FilterGroups:
           - - Type: EVENT
               Pattern: PUSH
-            - Type: HEAD_REF  # Build on commits to branch reinforce2019
-              Pattern: '^refs/heads/reinforce2019'
             - Type: HEAD_REF  # Build on commits to branch master
               Pattern: '^refs/heads/master'
+          - - Type: EVENT
+              Pattern: PUSH
             - Type: HEAD_REF  # Build on tags like v1.2.3 and v1.2.3-testing
               Pattern: '^refs/tags\/v[0-9]+\.[0-9]+\.[0-9]+(\-(prod|pre|testing))?$'
       Tags:


### PR DESCRIPTION
* Allow setting the CodeBuild project name (as project names can't be changed)
* Fix typo in IAM Policy S3 resource ARN
* Fix IAM Policy CloudWatch log policy statements
* Clarify CodeBuild project description
* Add PrivilegedMode true to fix Docker errors
* Fix GitHub location URL
* Fix FilterGroup for tagged commits
* Update documentation to conform to new AWS CodeBuild provisioning method 
* Add check to prevent CodeBuild rebuilds 

This fixes bugs in #1285 