### PR TITLE
Cloudtrail mapping

### DIFF
--- a/mq/plugins/cloudtrail.py
+++ b/mq/plugins/cloudtrail.py
@@ -24,6 +24,8 @@ class message(object):
             'details.serviceeventdetails',
             'details.requestparameters.attribute',
             'details.requestparameters.bucketpolicy.statement.principal',
+            'details.requestparameters.bucketpolicy.statement.principal.service',
+            'details.requestparameters.bucketpolicy.statement.principal.aws',
             'details.requestparameters.callerreference',
             'details.requestparameters.description',
             'details.requestparameters.describeflowlogsrequest.filter.value',

--- a/mq/plugins/cloudtrail.py
+++ b/mq/plugins/cloudtrail.py
@@ -23,7 +23,6 @@ class message(object):
             'details.apiversion',
             'details.serviceeventdetails',
             'details.requestparameters.attribute',
-            'details.requestparameters.bucketpolicy.statement.principal',
             'details.requestparameters.bucketpolicy.statement.principal.service',
             'details.requestparameters.bucketpolicy.statement.principal.aws',
             'details.requestparameters.callerreference',


### PR DESCRIPTION
This is to prevent details.requestparameters.bucketpolicy.statement.principal.aws being mapped as a url and subsequent service entries being mapped as a keyword causing them to conflict because they were originally only registered as "details.requestparameters.bucketpolicy.statement.principal"