### PR TITLE
Add RequestError as another handled error type in bulk processing.

### DIFF
--- a/mozdef_util/mozdef_util/elasticsearch_client.py
+++ b/mozdef_util/mozdef_util/elasticsearch_client.py
@@ -2,8 +2,8 @@ import json
 
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
-from elasticsearch.exceptions import NotFoundError
-from elasticsearch.helpers import bulk, BulkIndexError, RequestError
+from elasticsearch.exceptions import NotFoundError, RequestError
+from elasticsearch.helpers import bulk, BulkIndexError
 
 from .query_models import SearchQuery, TermMatch, AggregatedResults, SimpleResults
 from .bulk_queue import BulkQueue

--- a/mozdef_util/mozdef_util/elasticsearch_client.py
+++ b/mozdef_util/mozdef_util/elasticsearch_client.py
@@ -3,7 +3,7 @@ import json
 from elasticsearch import Elasticsearch
 from elasticsearch_dsl import Search
 from elasticsearch.exceptions import NotFoundError
-from elasticsearch.helpers import bulk, BulkIndexError
+from elasticsearch.helpers import bulk, BulkIndexError, RequestError
 
 from .query_models import SearchQuery, TermMatch, AggregatedResults, SimpleResults
 from .bulk_queue import BulkQueue
@@ -128,7 +128,7 @@ class ElasticsearchClient():
             document['_type'] = DOCUMENT_TYPE
         try:
             bulk(self.es_connection, documents)
-        except BulkIndexError as e:
+        except (BulkIndexError, RequestError) as e:
             logger.error("Error bulk indexing: " + str(e))
 
     def finish_bulk(self):


### PR DESCRIPTION
 Observed when processing incomplete (ie test) log entries. Mentioned in a discussion here
https://github.com/mozilla/MozDef/issues/1402
with errors of sort
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/threading.py", line 812, in __bootstrap_inner
    self.run()
  File "/usr/lib64/python2.7/threading.py", line 765, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/opt/mozdef/envs/mozdef/mozdef_util/mozdef_util/bulk_queue.py", line 29, in flush_periodically
    self.flush()
  File "/opt/mozdef/envs/mozdef/mozdef_util/mozdef_util/bulk_queue.py", line 55, in flush
    self.es_client.save_documents(self.list)
  File "/opt/mozdef/envs/mozdef/mozdef_util/mozdef_util/elasticsearch_client.py", line 126, in save_documents
    bulk(self.es_connection, documents)
  File "/opt/mozdef/envs/python/lib/python2.7/site-packages/elasticsearch/helpers/__init__.py", line 257, in bulk
    for ok, item in streaming_bulk(client, actions, *args, **kwargs):
  File "/opt/mozdef/envs/python/lib/python2.7/site-packages/elasticsearch/helpers/__init__.py", line 192, in streaming_bulk
    raise_on_error, *args, **kwargs)
  File "/opt/mozdef/envs/python/lib/python2.7/site-packages/elasticsearch/helpers/__init__.py", line 99, in _process_bulk_chunk
    raise e
RequestError: RequestError(400, u'action_request_validation_exception', u'Validation Failed: 1: type is missing;2: type is missing;3: type is missing;4: type is missing;')
```
with this change the errors now look like
```
2019-08-27T21:56:17.079032+00:00 - esworker_eventtask.py - INFO - started without uwsgi
2019-08-27T22:00:17.927844+00:00 - esworker_eventtask.py - ERROR - Error bulk indexing: RequestError(400, u'action_request_validation_exception', u'Validation Failed: 1: type is missing;')
2019-08-27T22:01:48.268631+00:00 - esworker_eventtask.py - ERROR - Error bulk indexing: RequestError(400, u'action_request_validation_exception', u'Validation Failed: 1: type is missing;')
```