### PR TITLE
Fix elasticsearch client test_get_indices test to work with new indices

### DIFF
--- a/tests/mozdef_util/test_elasticsearch_client.py
+++ b/tests/mozdef_util/test_elasticsearch_client.py
@@ -411,9 +411,16 @@ class TestGetIndices(ElasticsearchClientTest):
         all_indices.sort()
         open_indices = self.es_client.get_open_indices()
         open_indices.sort()
-        expected_indices = [self.alert_index_name, self.previous_event_index_name, self.event_index_name, 'test_index']
-        assert all_indices == expected_indices
-        assert open_indices == expected_indices
+        expected_indices = [
+            self.alert_index_name,
+            self.previous_event_index_name,
+            self.event_index_name,
+            'test_index'
+        ]
+        assert all([
+            ind in all_indices and ind in open_indices
+            for ind in expected_indices
+        ])
 
     def test_closed_get_indices(self):
         if self.config_delete_indexes:


### PR DESCRIPTION
Please merge this before `geomodel-v-0-1`, `alert-aws-privshare` or `alert-servicenow-uid0`.