### PR TITLE
Remove logger entry for alert plugins receiving alerts

### DIFF
--- a/alerts/lib/alert_plugin_set.py
+++ b/alerts/lib/alert_plugin_set.py
@@ -1,12 +1,7 @@
 from mozdef_util.plugin_set import PluginSet
-from mozdef_util.utilities.logger import logger
 
 
 class AlertPluginSet(PluginSet):
 
     def send_message_to_plugin(self, plugin_class, message, metadata=None):
-        if 'utctimestamp' in message and 'summary' in message:
-            message_log_str = '{0} received message: ({1}) {2}'.format(plugin_class.__module__, message['utctimestamp'], message['summary'])
-            logger.info(message_log_str)
-
         return plugin_class.onMessage(message), metadata


### PR DESCRIPTION
This code was originally put in place when `alert actions` used to be `alert plugins`, and we wanted to know when each and every alert action was triggered. Now, we don't really care when alert plugins receive alerts.