### PR TITLE
Add LDAP bruteforce alert

### DIFF
--- a/alerts/ldap_bruteforce.conf
+++ b/alerts/ldap_bruteforce.conf
@@ -1,0 +1,3 @@
+[options]
+threshold_count = 10
+search_depth_min = 120

--- a/alerts/ldap_bruteforce.conf
+++ b/alerts/ldap_bruteforce.conf
@@ -1,3 +1,4 @@
 [options]
 threshold_count = 1
 search_depth_min = 60
+host_exclusions = foo.example.com,bar.example.com 

--- a/alerts/ldap_bruteforce.conf
+++ b/alerts/ldap_bruteforce.conf
@@ -1,3 +1,3 @@
 [options]
-threshold_count = 10
-search_depth_min = 120
+threshold_count = 1
+search_depth_min = 60

--- a/alerts/ldap_bruteforce.py
+++ b/alerts/ldap_bruteforce.py
@@ -21,7 +21,7 @@ class AlertLdapBruteforce(AlertTask):
         ])
 
         for host_exclusion in self.config.host_exclusion.split(","):
-            search_query.add_must_not([TermMatch("hostname", host_exclusion)])
+            search_query.add_must_not([TermMatch("details.server", host_exclusion)])
 
         self.filtersManual(search_query)
         self.searchEventsAggregated('details.user', samplesLimit=10)

--- a/alerts/ldap_bruteforce.py
+++ b/alerts/ldap_bruteforce.py
@@ -14,10 +14,11 @@ class AlertLdapBruteforce(AlertTask):
     def main(self):
         self.parse_config('ldap_bruteforce.conf', ['threshold_count', 'search_depth_min'])
         search_query = SearchQuery(minutes=int(self.config.search_depth_min))
+        search_query.add_must_not(TermMatch('details.user', ''))
         search_query.add_must([
             TermMatch('category', 'ldap'),
             TermMatch('details.response.error', 'LDAP_INVALID_CREDENTIALS'),
-            TermMatch('details.authenticated', 'False')
+            TermMatch('details.authenticated', 'False'),
         ])
         self.filtersManual(search_query)
         self.searchEventsAggregated('details.user', samplesLimit=10)

--- a/alerts/ldap_bruteforce.py
+++ b/alerts/ldap_bruteforce.py
@@ -20,7 +20,7 @@ class AlertLdapBruteforce(AlertTask):
             TermMatch('details.response.error', 'LDAP_INVALID_CREDENTIALS'),
         ])
 
-        for host_exclusion in self.config.host_exclusion.split(","):
+        for host_exclusion in self.config.host_exclusions.split(","):
             search_query.add_must_not([TermMatch("details.server", host_exclusion)])
 
         self.filtersManual(search_query)

--- a/alerts/ldap_bruteforce.py
+++ b/alerts/ldap_bruteforce.py
@@ -18,7 +18,6 @@ class AlertLdapBruteforce(AlertTask):
         search_query.add_must([
             TermMatch('category', 'ldap'),
             TermMatch('details.response.error', 'LDAP_INVALID_CREDENTIALS'),
-            TermMatch('details.authenticated', 'False'),
         ])
         self.filtersManual(search_query)
         self.searchEventsAggregated('details.user', samplesLimit=10)

--- a/alerts/ldap_bruteforce.py
+++ b/alerts/ldap_bruteforce.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+
+
+from lib.alerttask import AlertTask
+from mozdef_util.query_models import SearchQuery, TermMatch
+
+
+class AlertLdapBruteforce(AlertTask):
+    def main(self):
+        self.parse_config('ldap_bruteforce.conf', ['threshold_count', 'search_depth_min'])
+        search_query = SearchQuery(minutes=int(self.config.search_depth_min))
+        search_query.add_must([
+            TermMatch('category', 'ldap'),
+            TermMatch('details.response.error', 'LDAP_INVALID_CREDENTIALS'),
+            TermMatch('details.authenticated', 'False')
+        ])
+        self.filtersManual(search_query)
+        self.searchEventsAggregated('details.user', samplesLimit=10)
+        self.walkAggregations(threshold=int(self.config.threshold_count))
+
+    def onAggregation(self, aggreg):
+        category = 'ldap'
+        tags = ['ldap']
+        severity = 'WARNING'
+        client_list = set()
+
+        for event in aggreg['allevents']:
+            client_list.add(event['_source']['details']['client'])
+
+        summary = 'LDAP Bruteforce Attack in Progress against user ({0}) from the following source ip(s): {1}'.format(
+            aggreg['value'],
+            ", ".join(sorted(client_list)[:10])
+        )
+        if len(client_list) >= 10:
+            summary += '...'
+
+        return self.createAlertDict(summary, category, tags, aggreg['events'], severity)

--- a/tests/alerts/test_ldap_bruteforce.py
+++ b/tests/alerts/test_ldap_bruteforce.py
@@ -26,6 +26,8 @@ class TestAlertLdapBruteforce(AlertTestSuite):
                         ]
                     }
                 ],
+                "authentication": "False",
+                "user": "jsmith@example.com",
                 "response": {
                     "error": 'LDAP_INVALID_CREDENTIALS',
                 }

--- a/tests/alerts/test_ldap_bruteforce.py
+++ b/tests/alerts/test_ldap_bruteforce.py
@@ -1,0 +1,99 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+from .positive_alert_test_case import PositiveAlertTestCase
+from .negative_alert_test_case import NegativeAlertTestCase
+
+from .alert_test_suite import AlertTestSuite
+
+
+class TestAlertLdapBruteforce(AlertTestSuite):
+    alert_filename = "ldap_bruteforce"
+    # This event is the default positive event that will cause the
+    # alert to trigger
+    default_event = {
+        "_source": {
+            "category": "ldap",
+            "details": {
+                "client": "1.2.3.4",
+                "requests": [
+                    {
+                        'verb': 'BIND',
+                        'details': [
+                            'method=128'
+                            'dn="mail=jsmith@example.com,o=com,dc=example"',
+                        ]
+                    }
+                ],
+                "response": {
+                    "error": 'LDAP_INVALID_CREDENTIALS',
+                }
+            }
+        }
+    }
+
+    # This alert is the expected result from running this task
+    default_alert = {
+        "category": "ldap",
+        "tags": ["ldap"],
+        "severity": "WARNING",
+        "summary": "LDAP Bruteforce Attack in Progress against user (jsmith@example.com) from the following source ip(s): 1.2.3.4",
+    }
+
+    # This alert is the expected result from this task against multiple matching events
+    default_alert_aggregated = AlertTestSuite.copy(default_alert)
+    default_alert_aggregated[
+        "summary"
+    ] = "LDAP Bruteforce Attack in Progress against user (jsmith@example.com) from the following source ip(s): 1.2.3.4"
+
+    test_cases = []
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test with default events and default alert expected",
+            events=AlertTestSuite.create_events(default_event, 1),
+            expected_alert=default_alert,
+        )
+    )
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test with default events and default alert expected - dedup",
+            events=AlertTestSuite.create_events(default_event, 2),
+            expected_alert=default_alert,
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event["_source"]["details"]["response"]["error"] = "LDAP_SUCCESS"
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test with default negative event", events=events
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event["_source"]["category"] = "bad"
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with events with incorrect category",
+            events=events,
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
+        event["_source"][
+            "utctimestamp"
+        ] = AlertTestSuite.subtract_from_timestamp_lambda({"minutes": 241})
+        event["_source"][
+            "receivedtimestamp"
+        ] = AlertTestSuite.subtract_from_timestamp_lambda({"minutes": 241})
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with old timestamp", events=events
+        )
+    )

--- a/tests/alerts/test_ldap_bruteforce.py
+++ b/tests/alerts/test_ldap_bruteforce.py
@@ -53,7 +53,7 @@ class TestAlertLdapBruteforce(AlertTestSuite):
     test_cases.append(
         PositiveAlertTestCase(
             description="Positive test with default events and default alert expected",
-            events=AlertTestSuite.create_events(default_event, 1),
+            events=AlertTestSuite.create_events(default_event, 10),
             expected_alert=default_alert,
         )
     )

--- a/tests/alerts/test_ldap_bruteforce.py
+++ b/tests/alerts/test_ldap_bruteforce.py
@@ -26,6 +26,7 @@ class TestAlertLdapBruteforce(AlertTestSuite):
                         ]
                     }
                 ],
+                "server": "ldap.example.com",
                 "user": "jsmith@example.com",
                 "response": {
                     "error": 'LDAP_INVALID_CREDENTIALS',

--- a/tests/alerts/test_ldap_bruteforce.py
+++ b/tests/alerts/test_ldap_bruteforce.py
@@ -26,7 +26,6 @@ class TestAlertLdapBruteforce(AlertTestSuite):
                         ]
                     }
                 ],
-                "authentication": "False",
                 "user": "jsmith@example.com",
                 "response": {
                     "error": 'LDAP_INVALID_CREDENTIALS',


### PR DESCRIPTION
Makes use of soon to be deployed user attribute to offer per user bruteforce alerting in MozDef.  This should stay as a WIP until we have verifiable data in prod with the exact formats to spec out.