### PR TITLE
Add whitelist to proxy drop ip alert

### DIFF
--- a/alerts/proxy_drop_ip.conf
+++ b/alerts/proxy_drop_ip.conf
@@ -1,0 +1,2 @@
+[options]
+ip_whitelist = 169.254.169.254

--- a/alerts/proxy_drop_ip.py
+++ b/alerts/proxy_drop_ip.py
@@ -13,6 +13,8 @@ import netaddr
 
 class AlertProxyDropIP(AlertTask):
     def main(self):
+        self.parse_config("proxy_drop_ip.conf", ["ip_whitelist"])
+
         search_query = SearchQuery(minutes=20)
 
         search_query.add_must(
@@ -27,6 +29,9 @@ class AlertProxyDropIP(AlertTask):
         ip_regex = "/[0-9a-fA-F]{1,4}.*/"
 
         search_query.add_must([QueryStringMatch("details.host: {}".format(ip_regex))])
+
+        for ip in self.config.ip_whitelist.split(","):
+            search_query.add_must_not([TermMatch("details.host", ip)])
 
         self.filtersManual(search_query)
         self.searchEventsAggregated("details.sourceipaddress", samplesLimit=10)

--- a/tests/alerts/test_proxy_drop_ip.py
+++ b/tests/alerts/test_proxy_drop_ip.py
@@ -66,6 +66,15 @@ class TestAlertProxyDropIP(AlertTestSuite):
 
     events = AlertTestSuite.create_events(default_event, 10)
     for event in events:
+        event["_source"]["details"]["host"] = "169.254.169.254"
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test with default negative event", events=events
+        )
+    )
+
+    events = AlertTestSuite.create_events(default_event, 10)
+    for event in events:
         event["_source"]["details"]["host"] = "1.idonotexist.com"
     test_cases.append(
         NegativeAlertTestCase(


### PR DESCRIPTION
Adds the capability to white-list certain destinations to prevent alerting when they happen.  In the 169 example, it's a demonstration of a misconfiguration, but not  asecurity issue.  This can be produced in a reporting means for sysadmin tasks, but is not a security event because this IP isn't routable via the proxy.