### PR TITLE
moves ldap details.tls to details.tls_encrypted as boolean

### DIFF
--- a/mq/plugins/ldap_fixup.py
+++ b/mq/plugins/ldap_fixup.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2014 Mozilla Corporation
+
+from mozdef_util.utilities.key_exists import key_exists
+
+
+class message(object):
+    def __init__(self):
+        '''
+        rewrites ldap's details.tls field and sets source
+        '''
+
+        self.registration = ['ldapChange', 'ldif']
+        self.priority = 5
+
+    def onMessage(self, message, metadata):
+
+        # check for category like 'ldap'
+        if key_exists('category', message):
+            if message.get['category'] == "ldap":
+                if key_exists('details.tls', message):
+                    message['details.tls_encrypted'] = message['details.tls']
+                    del message['details']['tls']
+
+        if 'source' not in message:
+            message['source'] = "ldap"
+            return (message, metadata)
+
+        return (message, metadata)

--- a/mq/plugins/ldap_fixup.py
+++ b/mq/plugins/ldap_fixup.py
@@ -12,7 +12,7 @@ class message(object):
         rewrites ldap's details.tls field and sets source
         '''
 
-        self.registration = ['ldapChange', 'ldif']
+        self.registration = ['ldapChange', 'ldif', 'LDAP-Humanizer']
         self.priority = 5
 
     def onMessage(self, message, metadata):

--- a/mq/plugins/ldap_fixup.py
+++ b/mq/plugins/ldap_fixup.py
@@ -12,20 +12,20 @@ class message(object):
         rewrites ldap's details.tls field and sets source
         '''
 
-        self.registration = ['ldapChange', 'ldif', 'LDAP-Humanizer']
+        self.registration = ['LDAP-Humanizer']
         self.priority = 5
 
     def onMessage(self, message, metadata):
 
-        # check for category like 'ldap'
+        # check for category like 'ldap' and rename the tls field
         if key_exists('category', message):
-            if message.get['category'] == "ldap":
+            data = message.get('category')
+            if data == 'ldap':
                 if key_exists('details.tls', message):
-                    message['details.tls_encrypted'] = message['details.tls']
-                    del message['details']['tls']
+                    message['details']['tls_encrypted'] = message['details']['tls']
+                    del(message['details']['tls'])
 
         if 'source' not in message:
-            message['source'] = "ldap"
-            return (message, metadata)
+            message['source'] = 'ldap'
 
         return (message, metadata)

--- a/tests/mq/plugins/test_ldap_fixup.py
+++ b/tests/mq/plugins/test_ldap_fixup.py
@@ -3,17 +3,18 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 # Copyright (c) 2017 Mozilla Corporation
 
-from mq.plugins.zoom_fixup import message
+from mq.plugins.ldap_fixup import message
 
 
 class TestLdapFixupPlugin():
     def setup(self):
         self.plugin = message()
 
-    def test_details_tls_rename(self):
+    def test_ldap_fixup_plugin(self):
         msg = {
             'summary': 'LDAP-Humanizer:45582:1.1.1.1',
             'hostname': 'random.host.com',
+            'category': 'ldap',
             'details': {
                 'tls': 'true',
                 'authenticated': 'true',
@@ -24,31 +25,10 @@ class TestLdapFixupPlugin():
         expected_message = {
             'summary': 'LDAP-Humanizer:45582:1.1.1.1',
             'hostname': 'random.host.com',
-            'details': {
-                'tls_encrypted': 'true',
-                'authenticated': 'true',
-            }
-        }
-        assert retmessage == expected_message
-        assert retmeta == {}
-
-    def test_source_addition(self):
-        msg = {
-            'summary': 'LDAP-Humanizer:45582:1.1.1.1',
-            'hostname': 'random.host.com',
-            'details': {
-                'tls': 'true',
-                'authenticated': 'true',
-            }
-        }
-        (retmessage, retmeta) = self.plugin.onMessage(msg, {})
-
-        expected_message = {
-            'summary': 'LDAP-Humanizer:45582:1.1.1.1',
-            'hostname': 'random.host.com',
+            'category': 'ldap',
             'source': 'ldap',
             'details': {
-                'tls': 'true',
+                'tls_encrypted': 'true',
                 'authenticated': 'true',
             }
         }

--- a/tests/mq/plugins/test_ldap_fixup.py
+++ b/tests/mq/plugins/test_ldap_fixup.py
@@ -1,0 +1,56 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+from mq.plugins.zoom_fixup import message
+
+
+class TestLdapFixupPlugin():
+    def setup(self):
+        self.plugin = message()
+
+    def test_details_tls_rename(self):
+        msg = {
+            'summary': 'LDAP-Humanizer:45582:1.1.1.1',
+            'hostname': 'random.host.com',
+            'details': {
+                'tls': 'true',
+                'authenticated': 'true',
+            }
+        }
+        (retmessage, retmeta) = self.plugin.onMessage(msg, {})
+
+        expected_message = {
+            'summary': 'LDAP-Humanizer:45582:1.1.1.1',
+            'hostname': 'random.host.com',
+            'details': {
+                'tls_encrypted': 'true',
+                'authenticated': 'true',
+            }
+        }
+        assert retmessage == expected_message
+        assert retmeta == {}
+
+    def test_source_addition(self):
+        msg = {
+            'summary': 'LDAP-Humanizer:45582:1.1.1.1',
+            'hostname': 'random.host.com',
+            'details': {
+                'tls': 'true',
+                'authenticated': 'true',
+            }
+        }
+        (retmessage, retmeta) = self.plugin.onMessage(msg, {})
+
+        expected_message = {
+            'summary': 'LDAP-Humanizer:45582:1.1.1.1',
+            'hostname': 'random.host.com',
+            'source': 'ldap',
+            'details': {
+                'tls': 'true',
+                'authenticated': 'true',
+            }
+        }
+        assert retmessage == expected_message
+        assert retmeta == {}


### PR DESCRIPTION
I figured it'd be better to not have to disparate fields called the same thing, moving this to details.tls_encrypted is descriptive and should not interfere with any other details.tls field.