### PR TITLE
Modify update geolocation script to require credentials 

### DIFF
--- a/cron/update_geolite_db.conf
+++ b/cron/update_geolite_db.conf
@@ -1,6 +1,5 @@
 [options]
 db_location = /opt/mozdef/envs/mozdef/data/GeoLite2-City.mmdb
 db_download_location = https://updates.maxmind.com/geoip/databases/GeoLite2-City/update
-# Set to empty string for no auth
-account_id = ""
-license_key = ""
+account_id = <insert account number>
+license_key = <insert license key>

--- a/cron/update_geolite_db.py
+++ b/cron/update_geolite_db.py
@@ -19,10 +19,7 @@ from mozdef_util.utilities.logger import logger, initLogger
 
 def fetch_db_data(db_download_location):
     logger.debug('Fetching db data from ' + db_download_location)
-    auth_creds = None
-    if options.account_id != '' and options.license_key != '':
-        logger.debug('Using credentials for maxmind')
-        auth_creds = (options.account_id, options.license_key)
+    auth_creds = (options.account_id, options.license_key)
     response = requests.get(db_download_location, auth=auth_creds)
     if not response.ok:
         raise Exception("Received bad response from maxmind server: {0}".format(response.text))

--- a/docker/compose/docker-compose-cloudy-mozdef.yml
+++ b/docker/compose/docker-compose-cloudy-mozdef.yml
@@ -64,9 +64,6 @@ services:
         max-size: "10m"
     env_file:
       - cloudy_mozdef.env
-    command: bash -c 'su - mozdef -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh'
-    volumes:
-      - geolite_db:/opt/mozdef/envs/mozdef/data
   alertactions:
     image: mozdef/mozdef_alertactions:latest
     logging:

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -119,9 +119,6 @@ services:
       cache_from:
         - mozdef/mozdef_base
         - mozdef_base:latest
-    command: bash -c 'su - mozdef -c /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh'
-    volumes:
-      - geolite_db:/opt/mozdef/envs/mozdef/data
   bootstrap:
     image: mozdef/mozdef_bootstrap
     build:

--- a/docker/compose/mozdef_base/Dockerfile
+++ b/docker/compose/mozdef_base/Dockerfile
@@ -38,10 +38,6 @@ ENV PYCURL_SSL_LIBRARY=nss
 # Create python virtual environment and install dependencies
 COPY --chown=mozdef:mozdef requirements.txt /opt/mozdef/envs/mozdef/requirements.txt
 
-COPY --chown=mozdef:mozdef cron/update_geolite_db.py /opt/mozdef/envs/mozdef/cron/update_geolite_db.py
-COPY --chown=mozdef:mozdef cron/update_geolite_db.conf /opt/mozdef/envs/mozdef/cron/update_geolite_db.conf
-COPY --chown=mozdef:mozdef cron/update_geolite_db.sh /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh
-
 COPY --chown=mozdef:mozdef mozdef_util /opt/mozdef/envs/mozdef/mozdef_util
 
 USER mozdef

--- a/docker/compose/mozdef_cron/files/cron_entries.txt
+++ b/docker/compose/mozdef_cron/files/cron_entries.txt
@@ -6,4 +6,3 @@ BASH_ENV=/env
 * * * * * /opt/mozdef/envs/mozdef/cron/eventStats.sh
 0 0 * * * /opt/mozdef/envs/mozdef/cron/esMaint.sh
 0 8 * * * /opt/mozdef/envs/mozdef/cron/pruneES.sh
-0 0 * * * /opt/mozdef/envs/mozdef/cron/update_geolite_db.sh


### PR DESCRIPTION
This also disables running that script by default, as an account needs to be created beforehand.