### PR TITLE
Allow meteor dev container with refresh on files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,12 @@ run-tests: run-tests-resources  ## Just run the tests (no build/get). Use `make 
 	docker run -it --rm mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && flake8 --config .flake8 ./"
 	docker run -it --rm --network=test-mozdef_default mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && py.test --delete_indexes --delete_queues $(TEST_CASE)"
 
+.PHONY: run-dev-meteor
+run-dev-meteor:  ## Run a local development meteor environment (useful for development)
+	docker-compose -f docker/compose/docker-compose.yml -f docker/compose/dev-meteor.yml -p $(NAME) $(BUILD_MODE) $(PARALLEL) $(NO_CACHE) base
+	docker-compose -f docker/compose/docker-compose.yml -f docker/compose/dev-meteor.yml -p $(NAME) $(BUILD_MODE) $(PARALLEL) $(NO_CACHE)
+	docker-compose -f docker/compose/docker-compose.yml -f docker/compose/dev-meteor.yml -p $(NAME) up -d
+
 .PHONY: rebuild-run-tests
 rebuild-run-tests: build-tests run-tests
 

--- a/docker/compose/dev-meteor.yml
+++ b/docker/compose/dev-meteor.yml
@@ -8,7 +8,7 @@ services:
       args:
         METEOR_BUILD: 'NO'
     restart: always
-    command: bash -c 'node -i'
+    command: bash -c 'cd /opt/mozdef/envs/mozdef/meteor;meteor npm install --save @babel/runtime;meteor'
     depends_on:
       - mongodb
       - rest
@@ -16,5 +16,3 @@ services:
       - default
     volumes:
         - ../../meteor:/opt/mozdef/envs/mozdef/meteor
-    stdin_open: true
-    tty: true

--- a/docker/compose/mozdef_meteor/Dockerfile
+++ b/docker/compose/mozdef_meteor/Dockerfile
@@ -48,10 +48,10 @@ USER mozdef
 
 # build meteor runtime if asked, if set to NO, only create the dir created above to mount to do live development
 RUN \
+  mkdir -p /opt/mozdef/envs/meteor/mozdef && \
+  cd /opt/mozdef/envs/mozdef/meteor && \
+  meteor npm install && \
   if [ "${METEOR_BUILD}" = "YES" ]; then \
-    mkdir -p /opt/mozdef/envs/meteor/mozdef && \
-    cd /opt/mozdef/envs/mozdef/meteor && \
-    meteor npm install && \
     echo "Starting meteor build" && \
     time meteor build --server localhost:3002 --directory /opt/mozdef/envs/meteor/mozdef && \
     ln --symbolic /opt/mozdef/envs/meteor/mozdef/node_modules /opt/mozdef/envs/mozdef/meteor/node_modules && \


### PR DESCRIPTION
This runs a dev meteor setup in a docker container (with `make run-dev-meteor`), and since we're mounting the local meteor directory, we can modify the files locally and the meteor container will autorefresh with the new file changes.