### PR TITLE
Fix test index set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ else
 endif
 
 .PHONY: test
-test: clean build-tests run-tests
+test: build-tests run-tests
 
 .PHONY: tests
 tests: build-tests run-tests  ## Run all tests (getting/building images as needed)
@@ -61,7 +61,6 @@ run-test: run-tests
 .PHONY: run-tests
 run-tests: run-tests-resources  ## Just run the tests (no build/get). Use `make TEST_CASE=tests/...` for specific tests only
 	docker run -it --rm mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && flake8 --config .flake8 ./"
-	#docker run -it --rm --network=test-mozdef_default mozdef/mozdef_tester bash
 	docker run -it --rm --network=test-mozdef_default mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && py.test --delete_indexes --delete_queues $(TEST_CASE)"
 
 .PHONY: run-dev-meteor

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ else
 endif
 
 .PHONY: test
-test: build-tests run-tests
+test: clean build-tests run-tests
 
 .PHONY: tests
 tests: build-tests run-tests  ## Run all tests (getting/building images as needed)
@@ -61,6 +61,7 @@ run-test: run-tests
 .PHONY: run-tests
 run-tests: run-tests-resources  ## Just run the tests (no build/get). Use `make TEST_CASE=tests/...` for specific tests only
 	docker run -it --rm mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && flake8 --config .flake8 ./"
+	#docker run -it --rm --network=test-mozdef_default mozdef/mozdef_tester bash
 	docker run -it --rm --network=test-mozdef_default mozdef/mozdef_tester bash -c "source /opt/mozdef/envs/python/bin/activate && py.test --delete_indexes --delete_queues $(TEST_CASE)"
 
 .PHONY: run-dev-meteor

--- a/tests/mozdef_util/test_elasticsearch_client.py
+++ b/tests/mozdef_util/test_elasticsearch_client.py
@@ -426,17 +426,18 @@ class TestGetIndices(ElasticsearchClientTest):
         next_day = current_day + timedelta(days=1)
         next_name = "{}{}{}".format(
             next_day.year, next_day.month, next_day.day
+        )
 
         next_index_name = "events-{}".format(next_name)
 
         assert all([expected in all_indices for expected in expected_indices])
         assert all([expected in open_indices for expected in expected_indices])
-        assert (len(expected_indices) == len(all_indices)) or\
-            (len(expected_indices) + 1 == len(all_indices) and\
-             next_index_name in all_indices)
-        assert (len(expected_indices) == len(open_indices)) or\
-            (len(expected_indices) + 1 == len(open_indices) and\
-             next_index_name in open_indices)
+        assert ((len(expected_indices) == len(all_indices)) or
+                (len(expected_indices) + 1 == len(all_indices) and
+                 next_index_name in all_indices))
+        assert ((len(expected_indices) == len(open_indices)) or
+                (len(expected_indices) + 1 == len(open_indices) and
+                 next_index_name in open_indices))
 
     def test_closed_get_indices(self):
         if self.config_delete_indexes:


### PR DESCRIPTION
This PR includes two changes:

1. An addition to our Makefile to clean docker before running tests and
2. A modification to a test in `test_elasticsearch_client.py` that will guarantee that, if execution of tests occurs across a change from one day to the next, that checks for indices will work as expected and include the new index created.