### PR TITLE
Comment out mongo external ports for docker test env

### DIFF
--- a/docker/compose/docker-compose-tests.yml
+++ b/docker/compose/docker-compose-tests.yml
@@ -33,8 +33,8 @@ services:
       - base
     restart: always
     command: ["bin/mongod", "--config", "/etc/mongod.conf"]
-    ports:
-      - 3002:3002
+    # ports:
+    #   - 3002:3002
     networks:
       - default
   rabbitmq:


### PR DESCRIPTION
This allows us to run a full docker env of mozdef, in addition to running as many iterations of the test environment at the same time. If we need to run these services on the local docker host, we can run `make run-tests-resources-external` 