### PR TITLE
Convert Hops to JSON

### DIFF
--- a/alerts/geomodel/alert.py
+++ b/alerts/geomodel/alert.py
@@ -33,6 +33,15 @@ class Hop(NamedTuple):
     origin: Origin
     destination: Origin
 
+    def to_json(self):
+        '''Convert a `Hop` to a fully JSON (`dict`) representation.
+        '''
+
+        return {
+            'origin': dict(self.origin._asdict()),
+            'destination': dict(self.destination._asdict()),
+        }
+
 
 class Alert(NamedTuple):
     '''A container for the data the alerts output by GeoModel contain.

--- a/alerts/geomodel_location.py
+++ b/alerts/geomodel_location.py
@@ -152,7 +152,7 @@ class AlertGeoModel(AlertTask):
             # TODO: When we update to Python 3.7+, change to asdict(alert_produced)
             alert_dict['details'] = {
                 'username': new_alert.username,
-                'hops': [dict(hop._asdict()) for hop in new_alert.hops]
+                'hops': [hop.to_json() for hop in new_alert.hops],
             }
 
             return alert_dict


### PR DESCRIPTION
Note: Before approving and merging the [GeoModel Enrichment](https://github.com/mozilla/MozDef/pull/1595) PR, I would like to have this PR approved and the former adjusted to accommodate these changes.

The problem I am trying to solve here was detected while working on the [GeoModel Enrichment](https://github.com/mozilla/MozDef/pull/1595) PR in which I determined that, to my surprise, hops were only [partially converted to JSON](https://github.com/mozilla/MozDef/pull/1595/commits/24fbfa3227ce3fef1a666ac4e832e285722e279b) in doing
```py
[dict(hop._asdict()) for hop in alert.hops]
```

This is a result of the fact that a `Hop` is itself a `NamedTuple` which contains `Origin` `NamedTuple`s.  Thus, the top-level `Hop` is converted to a `dict` of the form
```py
{
  "origin": Origin(...),
  "destination": Origin(...),
}
```

This PR addresses this by adding a method to `Hop` called `to_json()` that performs a deep conversion so that plugins dealing with GeoModel alerts will receive `Hop` data as fully nested JSON.