### PR TITLE
remove empty start time keys, or assume value

### DIFF
--- a/mq/plugins/zoom_fixup.py
+++ b/mq/plugins/zoom_fixup.py
@@ -74,16 +74,23 @@ class message(object):
                 # JMESPath likes to silently return a None object
                 if mappedvalue is not None:
                     newmessage['details'][key] = mappedvalue
-            # Some zoom messages don't contain details.start_time or details.original_sched_start_time.
+            # Some zoom messages don't contain values within details.payload.object.start_time or details.payload.old_object.start_time.
             # so we set it to original start time, if there is no time data, we remove the key from the message.
-            if key_exists('details.start_time', newmessage) and key_exists('details.original_sched_start_time', newmessage):
-                if newmessage['details']['start_time'] == '' and newmessage['details']['original_sched_start_time'] == '':
+            if key_exists('details.payload.object.start_time', message):
+                if message['details']['payload']['object']['start_time'] != '':
+                    newmessage['details']['start_time'] = message['details']['payload']['object']['start_time']
+                else:
                     del newmessage['details']['start_time']
+            if key_exists('details.payload.old_object.start_time', message):
+                if message['details']['payload']['old_object']['start_time'] != '':
+                    newmessage['details']['original_sched_start_time'] = message['details']['payload']['old_object']['start_time']
+                else:
                     del newmessage['details']['original_sched_start_time']
-                elif newmessage['details']['start_time'] == '':
-                    newmessage['details']['start_time'] = newmessage['details']['original_sched_start_time']
-                elif newmessage['details']['original_sched_start_time'] == '':
-                    newmessage['details']['original_sched_start_time'] = newmessage['details']['start_time']
+            # Duration can exist in details.payload.object and details.payload.old_object, let's ensure we are capturing these correctly for updated meetings.
+            if key_exists('details.payload.object.duration', message):
+                newmessage['details']['duration'] = message['details']['payload']['object']['duration']
+            if key_exists('details.payload.old_object.duration', message):
+                newmessage['details']['original_sched_duration'] = message['details']['payload']['old_object']['duration']
 
         else:
             newmessage = None

--- a/mq/plugins/zoom_fixup.py
+++ b/mq/plugins/zoom_fixup.py
@@ -74,11 +74,16 @@ class message(object):
                 # JMESPath likes to silently return a None object
                 if mappedvalue is not None:
                     newmessage['details'][key] = mappedvalue
-            # Some zoom messages don't contain details.start_time
-            # so we set it to original start time
+            # Some zoom messages don't contain details.start_time or details.original_sched_start_time.
+            # so we set it to original start time, if there is no time data, we remove the key from the message.
             if key_exists('details.start_time', newmessage) and key_exists('details.original_sched_start_time', newmessage):
-                if newmessage['details']['start_time'] == '':
+                if newmessage['details']['start_time'] == '' and newmessage['details']['original_sched_start_time'] == '':
+                    del newmessage['details']['start_time']
+                    del newmessage['details']['original_sched_start_time']
+                elif newmessage['details']['start_time'] == '':
                     newmessage['details']['start_time'] = newmessage['details']['original_sched_start_time']
+                elif newmessage['details']['original_sched_start_time'] == '':
+                    newmessage['details']['original_sched_start_time'] = newmessage['details']['start_time']
 
         else:
             newmessage = None

--- a/tests/mq/plugins/test_zoom_fixup.py
+++ b/tests/mq/plugins/test_zoom_fixup.py
@@ -299,14 +299,15 @@ class TestZoomFixupPlugin():
                 'payload': {
                     'account_id': 'ABCDEFG123456',
                     'object': {
-                        'account_id': 'HIJKLMN123456',
+                        'account_id': 'ABCDEFG123456',
                         'id': '123456789',
                         'type': '2',
                         'uuid': 'aodij/OWIE9241048=',
                         'start_time': ''
                     },
                     'old_object': {
-                        'start_time': '2020-02-11T20:25:30Z'
+                        'start_time': '2020-02-11T20:25:30Z',
+                        'duration': '60'
                     }
                 }
             }
@@ -329,13 +330,13 @@ class TestZoomFixupPlugin():
                 'type': '2',
                 'uuid': 'aodij/OWIE9241048=',
                 'original_sched_start_time': '2020-02-11T20:25:30Z',
-                'start_time': '2020-02-11T20:25:30Z'
+                'original_sched_duration': '60'
             }
         }
         assert retmessage == expected_message
         assert retmeta == {}
 
-    def test_multiple_empty_start_time_strings(self):
+    def test_empty_original_sched_start_time_strings(self):
         msg = {
             'summary': 'zoom_event',
             'source': 'api_aws_lambda',
@@ -349,12 +350,17 @@ class TestZoomFixupPlugin():
                 'payload': {
                     'account_id': 'ABCDEFG123456',
                     'object': {
-                        'account_id': 'HIJKLMN123456',
+                        'account_id': 'ABCDEFG123456',
                         'id': '123456789',
                         'type': '2',
                         'uuid': 'aodij/OWIE9241048=',
-                        'original_sched_start_time': '',
                         'start_time': ''
+                    },
+                    'old_object': {
+                        'id': '123456789',
+                        'type': '2',
+                        'start_time': '',
+                        'duration': '60'
                     }
                 }
             }
@@ -375,7 +381,8 @@ class TestZoomFixupPlugin():
                 'event': 'meeting.updated',
                 'id': '123456789',
                 'type': '2',
-                'uuid': 'aodij/OWIE9241048='
+                'uuid': 'aodij/OWIE9241048=',
+                'original_sched_duration': '60'
             }
         }
         assert retmessage == expected_message

--- a/tests/mq/plugins/test_zoom_fixup.py
+++ b/tests/mq/plugins/test_zoom_fixup.py
@@ -362,7 +362,7 @@ class TestZoomFixupPlugin():
         (retmessage, retmeta) = self.plugin.onMessage(msg, {})
 
         expected_message = {
-            'summary': 'zoom: meeting.created',
+            'summary': 'zoom: meeting.updated',
             'category': 'zoom',
             'source': 'api_aws_lambda',
             'hostname': 'zoom_host',

--- a/tests/mq/plugins/test_zoom_fixup.py
+++ b/tests/mq/plugins/test_zoom_fixup.py
@@ -74,7 +74,7 @@ class TestZoomFixupPlugin():
                         'uuid': 'aodij/OWIE9241048=',
                         "participant": {
                             'user_id': '12039103',
-                            'user_name': 'Random User',
+                            'user_name': 'Random User'
                         }
                     }
                 }
@@ -98,7 +98,7 @@ class TestZoomFixupPlugin():
                 'type': '4',
                 'uuid': 'aodij/OWIE9241048=',
                 'participant_username': 'Random User',
-                'participant_user_id': '12039103',
+                'participant_user_id': '12039103'
             }
         }
         assert retmessage == expected_message
@@ -122,7 +122,7 @@ class TestZoomFixupPlugin():
                     'object': {
                         'id': '123456789',
                         'type': '2',
-                        'uuid': 'aodij/OWIE9241048=',
+                        'uuid': 'aodij/OWIE9241048='
                     }
                 }
             }
@@ -145,7 +145,7 @@ class TestZoomFixupPlugin():
                 'type': '2',
                 'user_id': '12o3i-294jo24jad',
                 'username': 'randomuser@randomco.com',
-                'uuid': 'aodij/OWIE9241048=',
+                'uuid': 'aodij/OWIE9241048='
             }
         }
         assert retmessage == expected_message
@@ -329,7 +329,53 @@ class TestZoomFixupPlugin():
                 'type': '2',
                 'uuid': 'aodij/OWIE9241048=',
                 'original_sched_start_time': '2020-02-11T20:25:30Z',
-                'start_time': '2020-02-11T20:25:30Z',
+                'start_time': '2020-02-11T20:25:30Z'
+            }
+        }
+        assert retmessage == expected_message
+        assert retmeta == {}
+
+    def test_multiple_empty_start_time_strings(self):
+        msg = {
+            'summary': 'zoom_event',
+            'source': 'api_aws_lambda',
+            'hostname': 'zoom_host',
+            'severity': 'info',
+            'eventsource': 'MozDef-EF-zoom',
+            'tags': ['zoom', 'MozDef-EF-zoom-dev'],
+            'category': 'zoom',
+            'details': {
+                'event': 'meeting.updated',
+                'payload': {
+                    'account_id': 'ABCDEFG123456',
+                    'object': {
+                        'account_id': 'HIJKLMN123456',
+                        'id': '123456789',
+                        'type': '2',
+                        'uuid': 'aodij/OWIE9241048=',
+                        'original_sched_start_time': '',
+                        'start_time': ''
+                    }
+                }
+            }
+        }
+        (retmessage, retmeta) = self.plugin.onMessage(msg, {})
+
+        expected_message = {
+            'summary': 'zoom: meeting.created',
+            'category': 'zoom',
+            'source': 'api_aws_lambda',
+            'hostname': 'zoom_host',
+            'severity': 'info',
+            'eventsource': 'MozDef-EF-zoom',
+            'tags': ['zoom', 'MozDef-EF-zoom-dev'],
+            'processname': 'zoom_webhook_api',
+            'details': {
+                'account_id': 'ABCDEFG123456',
+                'event': 'meeting.updated',
+                'id': '123456789',
+                'type': '2',
+                'uuid': 'aodij/OWIE9241048='
             }
         }
         assert retmessage == expected_message


### PR DESCRIPTION
empty values cause parsing errors within MozDef, so we correct for these with this PR.