### PR TITLE
Fix triagebot matching

### DIFF
--- a/alerts/actions/triage_bot.json
+++ b/alerts/actions/triage_bot.json
@@ -1,4 +1,10 @@
 {
+  "enabled_alert_classnames": [
+    "AlertGenericLoader:ssh_open_crit",
+    "AlertAuthSignRelengSSH",
+    "AlertGenericLoader:duosecurity_bypass_generated",
+    "AlertGenericLoader:duosecurity_bypass_used"
+  ],
   "oauth_url": "https://auth.mozilla.auth0.com/oauth/token",
   "person_api_base": "https://person-api.sso.mozilla.com",
   "person_api_audience": "api.sso.mozilla.com",

--- a/alerts/actions/triage_bot.py
+++ b/alerts/actions/triage_bot.py
@@ -765,15 +765,9 @@ def _update_duplicate_chain(
 
 
 def _request_builder(alert_classname: str) -> RequestBuilderInterface:
-    '''Maps the classnames of alerts to functions used to handle alerts of these
-    kind in order to produce an `AlertTriageRequest`.
-
-    This alert action's configuration also supports a list of classnames that can
-    be used to narrow the list of alerts that the action will handle.
-    Note that the alert action will convert classnames to lowercase, so classnames
-    must be provided as they appear below.
-    '''
-
+    # Note that the alert action will convert classnames to lowercase, so
+    # classnames in a config's `enabled_alert_classnames` must be provided
+    # as they appear below.
     SUPPORTED_ALERTS = {
         'AlertGenericLoader:ssh_open_crit': _make_sensitive_host_access,
         'AlertAuthSignRelengSSH': _make_ssh_access_releng,

--- a/alerts/actions/triage_bot.py
+++ b/alerts/actions/triage_bot.py
@@ -24,6 +24,7 @@ CONFIG_FILE = os.path.join(os.path.dirname(__file__), "triage_bot.json")
 Alert = types.Dict[types.Any, types.Any]
 Email = str
 
+
 class AlertLabel(Enum):
     """Enumerates each of the alerts supported by the triage bot.
     """
@@ -355,7 +356,7 @@ def try_make_outbound(
     """Attempt to determine the kind of alert contained in `alert` in
     order to produce an `AlertTriageRequest` destined for the web server comp.
     """
-    
+
     _source = alert.get("_source", {})
 
     alert_class_name = _source.get('classname')

--- a/scripts/ingest/insert_elasticsearch.py
+++ b/scripts/ingest/insert_elasticsearch.py
@@ -28,50 +28,26 @@ true = True
 false = False
 null = None
 
-SSH_ACCESS_EVENT = {
-    "receivedtimestamp": "2020-04-15T22:01:33.799290+00:00",
-    "mozdefhostname": "mozdef1.private.mdc1.mozilla.com",
-    "details": {
-        "program": "sshd",
-        "eventsourceipaddress": "10.48.75.211",
-        "username": "emrose",
-    },
-    "tags": [".source.moz_net"],
-    "source": "authpriv",
-    "processname": "sshd",
-    "severity": "INFO",
-    "processid": "31365",
-    "summary": "pam_unix(sshd:session): session opened for user emrose by (uid=0)",
-    "hostname": "mozdefalert.private.mdc1.mozilla.com",
-    "facility": "authpriv",
-    "utctimestamp": "2020-04-15T22:01:33+00:00",
-    "timestamp": "2020-04-15T22:01:33+00:00",
-    "category": "syslog",
-    "type": "event",
-    "plugins": ["parse_sshd", "parse_su", "sshdFindIP"],
-}
-
 # Fill in with events you want to write to elasticsearch
 # NEED TO MODIFY
 events = [
-#    {
-#        "category": "testcategory",
-#        "details": {
-#            "program": "sshd",
-#            "type": "Success Login",
-#            "username": "ttesterson",
-#            "sourceipaddress": random_ip(),
-#        },
-#        "hostname": "i-99999999",
-#        "mozdefhostname": socket.gethostname(),
-#        "processid": "1337",
-#        "processname": "auth0_cron",
-#        "severity": "INFO",
-#        "source": "auth0",
-#        "summary": "login invalid ldap_count_entries failed",
-#        "tags": ["auth0"],
-#    }
-    SSH_ACCESS_EVENT,
+    {
+        "category": "testcategory",
+        "details": {
+            "program": "sshd",
+            "type": "Success Login",
+            "username": "ttesterson",
+            "sourceipaddress": random_ip(),
+        },
+        "hostname": "i-99999999",
+        "mozdefhostname": socket.gethostname(),
+        "processid": "1337",
+        "processname": "auth0_cron",
+        "severity": "INFO",
+        "source": "auth0",
+        "summary": "login invalid ldap_count_entries failed",
+        "tags": ["auth0"],
+    }
 ]
 
 es_client = ElasticsearchClient(options.elasticsearch_host)
@@ -84,3 +60,4 @@ for event in events:
     es_client.save_event(body=event)
     print("Wrote event to elasticsearch")
     time.sleep(0.2)
+

--- a/scripts/ingest/insert_elasticsearch.py
+++ b/scripts/ingest/insert_elasticsearch.py
@@ -60,4 +60,3 @@ for event in events:
     es_client.save_event(body=event)
     print("Wrote event to elasticsearch")
     time.sleep(0.2)
-

--- a/scripts/ingest/insert_elasticsearch.py
+++ b/scripts/ingest/insert_elasticsearch.py
@@ -28,26 +28,50 @@ true = True
 false = False
 null = None
 
+SSH_ACCESS_EVENT = {
+    "receivedtimestamp": "2020-04-15T22:01:33.799290+00:00",
+    "mozdefhostname": "mozdef1.private.mdc1.mozilla.com",
+    "details": {
+        "program": "sshd",
+        "eventsourceipaddress": "10.48.75.211",
+        "username": "emrose",
+    },
+    "tags": [".source.moz_net"],
+    "source": "authpriv",
+    "processname": "sshd",
+    "severity": "INFO",
+    "processid": "31365",
+    "summary": "pam_unix(sshd:session): session opened for user emrose by (uid=0)",
+    "hostname": "mozdefalert.private.mdc1.mozilla.com",
+    "facility": "authpriv",
+    "utctimestamp": "2020-04-15T22:01:33+00:00",
+    "timestamp": "2020-04-15T22:01:33+00:00",
+    "category": "syslog",
+    "type": "event",
+    "plugins": ["parse_sshd", "parse_su", "sshdFindIP"],
+}
+
 # Fill in with events you want to write to elasticsearch
 # NEED TO MODIFY
 events = [
-    {
-        "category": "testcategory",
-        "details": {
-            "program": "sshd",
-            "type": "Success Login",
-            "username": "ttesterson",
-            "sourceipaddress": random_ip(),
-        },
-        "hostname": "i-99999999",
-        "mozdefhostname": socket.gethostname(),
-        "processid": "1337",
-        "processname": "auth0_cron",
-        "severity": "INFO",
-        "source": "auth0",
-        "summary": "login invalid ldap_count_entries failed",
-        "tags": ["auth0"],
-    }
+#    {
+#        "category": "testcategory",
+#        "details": {
+#            "program": "sshd",
+#            "type": "Success Login",
+#            "username": "ttesterson",
+#            "sourceipaddress": random_ip(),
+#        },
+#        "hostname": "i-99999999",
+#        "mozdefhostname": socket.gethostname(),
+#        "processid": "1337",
+#        "processname": "auth0_cron",
+#        "severity": "INFO",
+#        "source": "auth0",
+#        "summary": "login invalid ldap_count_entries failed",
+#        "tags": ["auth0"],
+#    }
+    SSH_ACCESS_EVENT,
 ]
 
 es_client = ElasticsearchClient(options.elasticsearch_host)

--- a/tests/alerts/actions/test_triage_bot.py
+++ b/tests/alerts/actions/test_triage_bot.py
@@ -335,26 +335,26 @@ class TestAlertRecognition(object):
 
         assert result is not None
 
-#    def test_recognizes_duo_bypass_codes_generated(self):
-#        msg = _duo_bypass_code_gen_alert()
-#
-#        result = bot.try_make_outbound(msg, self.mock_config, "")
-#
-#        assert result is not None
-#
-#    def test_recognizes_duo_bypass_codes_used(self):
-#        msg = _duo_bypass_code_used_alert()
-#
-#        result = bot.try_make_outbound(msg, self.mock_config, "")
-#
-#        assert result is not None
-#
-#    def test_recognizes_ssh_access_releng(self):
-#        msg = _ssh_access_releng_alert()
-#
-#        result = bot.try_make_outbound(msg, self.mock_config, "")
-#
-#        assert result is not None
+    def test_recognizes_duo_bypass_codes_generated(self):
+        msg = _duo_bypass_code_gen_alert()
+
+        result = bot.try_make_outbound(msg, self.mock_config, "")
+
+        assert result is not None
+
+    def test_recognizes_duo_bypass_codes_used(self):
+        msg = _duo_bypass_code_used_alert()
+
+        result = bot.try_make_outbound(msg, self.mock_config, "")
+
+        assert result is not None
+
+    def test_recognizes_ssh_access_releng(self):
+        msg = _ssh_access_releng_alert()
+
+        result = bot.try_make_outbound(msg, self.mock_config, "")
+
+        assert result is not None
 
 
 class TestPersonAPI:

--- a/tests/alerts/actions/test_triage_bot.py
+++ b/tests/alerts/actions/test_triage_bot.py
@@ -16,6 +16,7 @@ def _ssh_sensitive_host_alert():
             "utctimestamp": "2019-11-04T23:04:36.351726+00:00",
             "severity": "WARNING",
             "summary": "Session opened on sensitive host by (1): tester [test@website.com]",
+            "classname": "AlertGenericLoader:ssh_open_crit",
             "category": "session",
             "tags": ["session", "successful"],
             "events": [
@@ -78,6 +79,7 @@ def _duo_bypass_code_gen_alert():
             "utctimestamp": "2019-11-04T23:36:36.966791+00:00",
             "severity": "NOTICE",
             "summary": "DuoSecurity MFA Bypass codes generated (1): tester@website.com [a.website.com]",
+            "classname": "AlertGenericLoader:duosecurity_bypass_generated",
             "category": "duo",
             "tags": ["duosecurity"],
             "events": [
@@ -146,6 +148,7 @@ def _duo_bypass_code_used_alert():
             "utctimestamp": "2019-10-21T15:55:46.033838+00:00",
             "severity": "NOTICE",
             "summary": "DuoSecurity MFA Bypass codes used to log in (1): tester@website.com [website.com]",
+            "classname": "AlertGenericLoader:duosecurity_bypass_used",
             "category": "bypassused",
             "tags": ["duosecurity", "used", "duo_bypass_codes_used"],
             "events": [
@@ -219,6 +222,7 @@ def _ssh_access_releng_alert():
             "utctimestamp": "2019-11-05T01:14:57.912292+00:00",
             "severity": "NOTICE",
             "summary": "SSH login from 10.49.48.100 on releng.website.com as user tester",
+            "classname": "AlertAuthSignRelengSSH",
             "category": "access",
             "tags": ["ssh"],
             "events": [
@@ -305,6 +309,12 @@ class TestAlertRecognition(object):
     """
 
     mock_config = bot.Config(
+        [
+            "AlertGenericLoader:ssh_open_crit",
+            "AlertAuthSignRelengSSH",
+            "AlertGenericLoader:duosecurity_bypass_generated",
+            "AlertGenericLoader:duosecurity_bypass_used"
+        ],
         "", "", "", "", "", 0, "", "", "", 0, "", "", "", "", "", ""
     )
 
@@ -312,7 +322,7 @@ class TestAlertRecognition(object):
         msg = _ssh_sensitive_host_alert()
 
         # Without the `session` tag, the alert should not fire.
-        msg["_source"]["tags"] = ["test"]
+        msg["_source"]["classname"] = "test"
 
         result = bot.try_make_outbound(msg, self.mock_config, "")
 


### PR DESCRIPTION
This PR introduces one main change to the Triage Bot alert action.  Rather than having the action register on _all_ alerts and then programmatically attempt to determine which alert an incoming alert is and then process it based on a few fields, we now instead match strictly on alert `classname`s.  With this addition, we are now able to introduce a configuration option to specify which _supported_ alerts should be enabled or not.