### PR TITLE
adding negative match for informational events, and adding unit tests

### DIFF
--- a/alerts/ldap_add.py
+++ b/alerts/ldap_add.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2014 Mozilla Corporation
 
 from lib.alerttask import AlertTask
-from mozdef_util.query_models import SearchQuery, TermMatch
+from mozdef_util.query_models import SearchQuery, TermMatch, WildcardMatch
 
 
 class ldapAdd(AlertTask):
@@ -16,6 +16,11 @@ class ldapAdd(AlertTask):
         search_query.add_must([
             TermMatch('category', 'ldapChange'),
             TermMatch('details.changetype', 'add')
+        ])
+
+        # ignore test accounts and attempts to create accounts that already exist.
+        search_query.add_must_not([
+            WildcardMatch('details.actor', '*bind*'),
         ])
 
         self.filtersManual(search_query)

--- a/alerts/ldap_delete.py
+++ b/alerts/ldap_delete.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2014 Mozilla Corporation
 
 from lib.alerttask import AlertTask
-from mozdef_util.query_models import SearchQuery, TermMatch
+from mozdef_util.query_models import SearchQuery, TermMatch, WildcardMatch
 
 
 class ldapDelete(AlertTask):
@@ -16,6 +16,11 @@ class ldapDelete(AlertTask):
         search_query.add_must([
             TermMatch('category', 'ldapChange'),
             TermMatch('details.changetype', 'delete')
+        ])
+
+        # ignore test accounts and attempts to create accounts that already exist.
+        search_query.add_must_not([
+            WildcardMatch('details.actor', '*bind*'),
         ])
 
         self.filtersManual(search_query)

--- a/alerts/ldap_group.py
+++ b/alerts/ldap_group.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2014 Mozilla Corporation
 
 from lib.alerttask import AlertTask
-from mozdef_util.query_models import SearchQuery, TermMatch, PhraseMatch
+from mozdef_util.query_models import SearchQuery, TermMatch, PhraseMatch, WildcardMatch
 
 
 class ldapGroupModify(AlertTask):
@@ -17,6 +17,11 @@ class ldapGroupModify(AlertTask):
             TermMatch('category', 'ldapChange'),
             TermMatch('details.changetype', 'modify'),
             PhraseMatch("summary", "groups")
+        ])
+
+        # ignore test accounts and attempts to create accounts that already exist.
+        search_query.add_must_not([
+            WildcardMatch('details.actor', '*bind*'),
         ])
 
         self.filtersManual(search_query)

--- a/tests/alerts/test_ldap_add.py
+++ b/tests/alerts/test_ldap_add.py
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+from .positive_alert_test_case import PositiveAlertTestCase
+from .negative_alert_test_case import NegativeAlertTestCase
+from .alert_test_suite import AlertTestSuite
+
+
+class TestldapAdd(AlertTestSuite):
+    alert_filename = "ldap_add"
+    # This event is the default positive event that will cause the
+    # alert to trigger
+    default_event = {
+        "_source": {
+            "summary": "dc=example mail=user_la@example.com,o=com,dc=example IP=1.2.3.4:49818 conn=527493 add cn=example_cn,ou=groups,dc=example",
+            "details": {
+                "dn": "cn=example_cn,ou=groups,dc=example",
+                "changetype": "add",
+                "actor": "dc=example mail=user_la@example.com,o=com,dc=example IP=1.2.3.4:49818 conn=527493"
+            },
+            "category": "ldapChange",
+            "processid": "1697",
+            "severity": "INFO",
+        }
+    }
+
+    # This alert is the expected result from running this task
+    default_alert = {
+        "category": "ldap",
+        "tags": ["ldap"],
+        "severity": "INFO",
+        "summary": "dc=example mail=user_la@example.com,o=com,dc=example IP=1.2.3.4:49818 conn=527493 added cn=example_cn,ou=groups,dc=example",
+    }
+
+    test_cases = []
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test case with good event",
+            events=[AlertTestSuite.create_event(default_event)],
+            expected_alert=default_alert
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 1})
+    event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 1})
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test case with an event with somewhat old timestamp",
+            events=[event],
+            expected_alert=default_alert
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['category'] = 'badcategory'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with bad eventName",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['changetype'] = 'delete'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with bad changetype",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['actor'] = 'dc=example uid=bind-generate-groups,ou=logins,dc=example IP=1.2.3.4:49818 conn=527493'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case where negative match exists",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'hours': 25})
+    event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'hours': 25})
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with event with old utctimestamp and receivedtimestamp",
+            events=[event],
+        )
+    )

--- a/tests/alerts/test_ldap_delete.py
+++ b/tests/alerts/test_ldap_delete.py
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+from .positive_alert_test_case import PositiveAlertTestCase
+from .negative_alert_test_case import NegativeAlertTestCase
+from .alert_test_suite import AlertTestSuite
+
+
+class TestldapDelete(AlertTestSuite):
+    alert_filename = "ldap_delete"
+    # This event is the default positive event that will cause the
+    # alert to trigger
+    default_event = {
+        "_source": {
+            "summary": "dc=example mail=user_la@example.com,o=com,dc=example IP=1.2.3.4:49818 conn=527493 delete cn=example_cn,ou=groups,dc=example",
+            "details": {
+                "dn": "cn=example_cn,ou=groups,dc=example",
+                "changetype": "delete",
+                "actor": "dc=example mail=user_la@example.com,o=com,dc=example IP=1.2.3.4:49818 conn=527493"
+            },
+            "category": "ldapChange",
+            "processid": "1697",
+            "severity": "INFO",
+        }
+    }
+
+    # This alert is the expected result from running this task
+    default_alert = {
+        "category": "ldap",
+        "tags": ["ldap"],
+        "severity": "INFO",
+        "summary": "dc=example mail=user_la@example.com,o=com,dc=example IP=1.2.3.4:49818 conn=527493 deleted cn=example_cn,ou=groups,dc=example",
+    }
+
+    test_cases = []
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test case with good event",
+            events=[AlertTestSuite.create_event(default_event)],
+            expected_alert=default_alert
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 1})
+    event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 1})
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test case with an event with somewhat old timestamp",
+            events=[event],
+            expected_alert=default_alert
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['category'] = 'badcategory'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with bad eventName",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['changetype'] = 'add'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with bad changetype",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['actor'] = 'dc=example uid=bind-generate-groups,ou=logins,dc=example IP=1.2.3.4:49818 conn=527493'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case where negative match exists",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'hours': 25})
+    event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'hours': 25})
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with event with old utctimestamp and receivedtimestamp",
+            events=[event],
+        )
+    )

--- a/tests/alerts/test_ldap_group.py
+++ b/tests/alerts/test_ldap_group.py
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+from .positive_alert_test_case import PositiveAlertTestCase
+from .negative_alert_test_case import NegativeAlertTestCase
+from .alert_test_suite import AlertTestSuite
+
+
+class TestldapGroupModify(AlertTestSuite):
+    alert_filename = "ldap_group"
+    # This event is the default positive event that will cause the
+    # alert to trigger
+    default_event = {
+        "_source": {
+            "summary": "mail=user_la@example.com,o=com,dc=example modify cn=example_cn,ou=groups,dc=example add:memberUid: anotheruser@example.com",
+            "details": {
+                "dn": "cn=example_cn,ou=groups,dc=example",
+                "changetype": "modify",
+                "actor": "mail=user_la@example.com,o=com,dc=example"
+            },
+            "category": "ldapChange",
+            "processid": "1697",
+            "severity": "INFO",
+        }
+    }
+
+    # This alert is the expected result from running this task
+    default_alert = {
+        "category": "ldap",
+        "tags": ["ldap"],
+        "severity": "INFO",
+        "summary": "mail=user_la@example.com,o=com,dc=example modify cn=example_cn,ou=groups,dc=example add:memberUid: anotheruser@example.com",
+    }
+
+    test_cases = []
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test case with good event",
+            events=[AlertTestSuite.create_event(default_event)],
+            expected_alert=default_alert
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 1})
+    event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'minutes': 1})
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test case with an event with somewhat old timestamp",
+            events=[event],
+            expected_alert=default_alert
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['category'] = 'badcategory'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with bad eventName",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['changetype'] = 'add'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with bad changetype",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['actor'] = 'uid=bind-generate-groups,ou=logins,ou=logins,dc=example'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case where negative match exists",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['utctimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'hours': 25})
+    event['_source']['receivedtimestamp'] = AlertTestSuite.subtract_from_timestamp_lambda({'hours': 25})
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with event with old utctimestamp and receivedtimestamp",
+            events=[event],
+        )
+    )


### PR DESCRIPTION
Adding negative match for ldap informational events to prevent them from being alerted on.