### PR TITLE
Make ip_source_enrichment registration consistent

### DIFF
--- a/alerts/plugins/ip_source_enrichment.py
+++ b/alerts/plugins/ip_source_enrichment.py
@@ -143,7 +143,7 @@ class message(object):
 
     def __init__(self):
         # Run plugin on all alerts
-        self.registration = '*'
+        self.registration = ['*']
         self._config = _load_config(CONFIG_FILE)
 
     def onMessage(self, message):


### PR DESCRIPTION
Other alert plugins have lists for their registration.  I found in testing in QA that the alert plugin runs as expected regardless of this change, however I feel that consistency is a good thing.