### PR TITLE
Have the ldap_group alert aggregate on details.email

### DIFF
--- a/alerts/ldap_group.py
+++ b/alerts/ldap_group.py
@@ -25,16 +25,22 @@ class ldapGroupModify(AlertTask):
         ])
 
         self.filtersManual(search_query)
-        # Search events
-        self.searchEventsSimple()
-        self.walkEvents()
+        self.searchEventsAggregated('details.email', samplesLimit=50)
+        self.walkAggregations(threshold=1, config={})
 
     # Set alert properties
-    def onEvent(self, event):
+    def onAggregation(self, agg):
+        email = agg['value']
+        events = agg['events']
+
         category = 'ldap'
         tags = ['ldap']
         severity = 'INFO'
-        summary = '{0}'.format(event['_source']['summary'])
+
+        if email is None:
+            summary = 'LDAP group change detected'
+        else:
+            summary = 'LDAP group change initiated by {0}'.format(email)
 
         # Create the alert object based on these properties
-        return self.createAlertDict(summary, category, tags, [event], severity)
+        return self.createAlertDict(summary, category, tags, events, severity)

--- a/alerts/ldap_group.py
+++ b/alerts/ldap_group.py
@@ -22,7 +22,7 @@ class ldapGroupModify(AlertTask):
         # ignore test accounts and attempts to create accounts that already exist.
         search_query.add_must_not([
             WildcardMatch('details.actor', '*bind*'),
-            WildcardMatch('details.changepairs', '*delete:member*')
+            WildcardMatch('details.changepairs', 'delete:*member*')
         ])
 
         self.filtersManual(search_query)

--- a/alerts/ldap_group.py
+++ b/alerts/ldap_group.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2014 Mozilla Corporation
 
 from lib.alerttask import AlertTask
-from mozdef_util.query_models import
+from mozdef_util.query_models import\
     PhraseMatch,\
     SearchQuery,\
     TermMatch,\

--- a/alerts/ldap_group.py
+++ b/alerts/ldap_group.py
@@ -6,7 +6,11 @@
 # Copyright (c) 2014 Mozilla Corporation
 
 from lib.alerttask import AlertTask
-from mozdef_util.query_models import SearchQuery, TermMatch, PhraseMatch, WildcardMatch
+from mozdef_util.query_models import
+    PhraseMatch,\
+    SearchQuery,\
+    TermMatch,\
+    WildcardMatch
 
 
 class ldapGroupModify(AlertTask):

--- a/mq/plugins/ldap_fixup.py
+++ b/mq/plugins/ldap_fixup.py
@@ -3,6 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 # Copyright (c) 2014 Mozilla Corporation
 
+import typing as types
+
 from mozdef_util.utilities.key_exists import key_exists
 
 
@@ -28,4 +30,32 @@ class message(object):
         if 'source' not in message:
             message['source'] = 'ldap'
 
+        details = message.get('details', {})
+        actor_str = details.get('actor', '')
+        actor_email = _parse_email_from_actor(actor_str)
+
+        if actor_email is None:
+            return (message, metadata)
+
+        username = actor_email.split('@')[0]
+
+        details['email'] = actor_email
+        details['username'] = username
+
+        message['details'] = details
+
         return (message, metadata)
+
+
+def _parse_email_from_actor(actor_str: str) -> types.Optional[str]:
+    '''Parse the email from a string like
+    `"mail=username@mozilla.com,o=com,dc=mozilla"`
+    '''
+
+    mapping = dict([
+        pair.split('=')
+        for pair in actor_str.split(',')
+        if '=' in pair
+    ])
+
+    return mapping.get('mail')

--- a/mq/plugins/ldap_fixup.py
+++ b/mq/plugins/ldap_fixup.py
@@ -35,6 +35,11 @@ class message(object):
         actor_email = _parse_email_from_actor(actor_str)
 
         if actor_email is None:
+            details['email'] = None
+            details['username'] = None
+
+            message['details'] = details
+
             return (message, metadata)
 
         username = actor_email.split('@')[0]

--- a/tests/alerts/test_ldap_group.py
+++ b/tests/alerts/test_ldap_group.py
@@ -17,7 +17,9 @@ class TestldapGroupModify(AlertTestSuite):
             "details": {
                 "dn": "cn=example_cn,ou=groups,dc=example",
                 "changetype": "modify",
-                "actor": "mail=user_la@example.com,o=com,dc=example"
+                "actor": "mail=user_la@example.com,o=com,dc=example",
+                "email": "user_la@example.com",
+                "username": "user_la"
             },
             "category": "ldapChange",
             "processid": "1697",
@@ -30,7 +32,7 @@ class TestldapGroupModify(AlertTestSuite):
         "category": "ldap",
         "tags": ["ldap"],
         "severity": "INFO",
-        "summary": "mail=user_la@example.com,o=com,dc=example modify cn=example_cn,ou=groups,dc=example add:memberUid: anotheruser@example.com",
+        "summary": "LDAP group change initiated by user_la@example.com",
     }
 
     test_cases = []

--- a/tests/mq/plugins/test_ldap_fixup.py
+++ b/tests/mq/plugins/test_ldap_fixup.py
@@ -18,6 +18,7 @@ class TestLdapFixupPlugin():
             'details': {
                 'tls': 'true',
                 'authenticated': 'true',
+                'actor': 'o=com,mail=tester@mozilla.com,dc=mozilla'
             }
         }
         (retmessage, retmeta) = self.plugin.onMessage(msg, {})
@@ -30,7 +31,26 @@ class TestLdapFixupPlugin():
             'details': {
                 'tls_encrypted': 'true',
                 'authenticated': 'true',
+                'email': 'tester@mozilla.com',
+                'username': 'tester',
+                'actor': 'o=com,mail=tester@mozilla.com,dc=mozilla'
             }
         }
         assert retmessage == expected_message
         assert retmeta == {}
+
+    def test_ldap_fixup_missing_actor(self):
+        msg = {
+            'summary': 'LDAP-Humanizer:45582:1.1.1.1',
+            'hostname': 'random.host.com',
+            'category': 'ldap',
+            'details': {
+                'tls': 'true',
+                'authenticated': 'true',
+            }
+        }
+
+        (retmessage, retmeta) = self.plugin.onMessage(msg, {})
+
+        assert 'email' not in retmessage['details']
+        assert 'username' not in retmessage['details']

--- a/tests/mq/plugins/test_ldap_fixup.py
+++ b/tests/mq/plugins/test_ldap_fixup.py
@@ -52,5 +52,5 @@ class TestLdapFixupPlugin():
 
         (retmessage, retmeta) = self.plugin.onMessage(msg, {})
 
-        assert 'email' not in retmessage['details']
-        assert 'username' not in retmessage['details']
+        assert retmessage['details'].get('email') is None
+        assert retmessage['details'].get('username') is None


### PR DESCRIPTION
This PR includes changes to:
1. The `ldap_fixup` MQ plugin that parses out the email address of an LDAP actor and adds its parts to `details.email` and `details.username`.
2. Modifications to the `ldap_group` alert that aggregate on the `details.email` field, including all of the aggregated into the one alert.

I have tested this in QA and verified that it behaves as expected.