### PR TITLE
Create vpn_assignment alert plugin

### DIFF
--- a/alerts/plugins/vpn_assignment.json
+++ b/alerts/plugins/vpn_assignment.json
@@ -1,0 +1,5 @@
+{
+  "indices_to_search": ["events"],
+  "search_window_hours": 6,
+  "vpn_ip_cidrs": []
+}

--- a/alerts/plugins/vpn_assignment.py
+++ b/alerts/plugins/vpn_assignment.py
@@ -116,7 +116,7 @@ def enrich(
 
     assign_events = sorted(
         [hit.get('_source', {}) for hit in search_fn(search_vpn_assignment)],
-        key=lambda evt: toUTC(evt['details']['utctimestamp']),
+        key=lambda evt: toUTC(evt['utctimestamp']),
         reverse=True,  # Sort into descending order from most recent to least.
     )
 

--- a/alerts/plugins/vpn_assignment.py
+++ b/alerts/plugins/vpn_assignment.py
@@ -74,7 +74,12 @@ class message(object):
         self.search = search_fn
 
     def onMessage(self, msg):
-        return enrich(msg, self.config.search_window_hours, self.search)
+        return enrich(
+            msg,
+            self.config.search_window_hours,
+            self.config.vpn_ip_cidrs,
+            self.search,
+        )
 
 
 def enrich(

--- a/alerts/plugins/vpn_assignment.py
+++ b/alerts/plugins/vpn_assignment.py
@@ -1,0 +1,129 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+import json
+import os
+import typing as types
+
+import netaddr
+
+from lib.config import ES
+from mozdef_util.elasticsearch_client import ElasticsearchClient
+from mozdef_util.query_models import SearchQuery, TermMatch, PhraseMatch
+
+
+CONFIG_FILE = os.path.join(
+    os.path.dirname(__file__),
+    __file__.replace('py', 'json'),
+)
+
+
+# TODO: Switch to dataclass when we adopt Python 3.7+
+
+class Config(types.NamedTuple):
+    '''Expected configuration for the plugin, loaded from JSON.
+    '''
+
+    indices_to_search: types.List[str]
+    search_window_hours: int
+    vpn_ip_cidrs: types.List[str]
+
+    def load(file_path: str) -> 'Config':
+        '''Attempt to parse a configuration from a JSON file.
+        '''
+
+        with open(file_path) as cfg_file:
+            return Config(**json.load(cfg_file))
+
+
+class message(object):
+    '''Alert plugin that handles any alert and attempts to enrich it with
+    information about VPN IP address assignments.
+
+    This plugin will add the following fields to the alert:
+
+    ```json
+    {
+        "details": {
+            "vpnassignment": {
+                "username": "user@mozilla.com",
+                "originalip": "1.2.3.4",
+            }
+        }
+    }
+    ```
+    '''
+
+    def __init__(self):
+        self.registration = ['*']
+
+        self.config = Config.load(CONFIG_FILE)
+
+        # Create a closure around an Elasticsearch client that can be invoked
+        # with search terms to find events in the configured indices.
+        es_client = ElasticsearchClient(ES['servers'])
+
+        def search_fn(query):
+            return query.execute(
+                es_client,
+                indices=self.config.indices_to_search,
+            ).get('hits', [])
+
+        self.search = search_fn
+
+    def onMessage(self, msg):
+        return enrich(msg, self.config.search_window_hours, self.search)
+
+
+def enrich(
+    alert: dict,
+    search_window_hours: int,
+    vpn_ip_cidrs: types.List[str],
+    search_fn: types.Callable[[SearchQuery], types.List[dict]],
+) -> dict:
+    '''Search for events that describe an assignment of a VPN IP address to
+    the sourceipaddress in an alert.
+    '''
+
+    details = alert.get('details', {})
+
+    source_ip = details.get('sourceipaddress')
+
+    if source_ip is None:
+        return alert
+
+    if netaddr.IPAddress(source_ip) not in netaddr.IPSet(vpn_ip_cidrs):
+        return alert
+
+    search_vpn_assignment = SearchQuery({
+        'hours': search_window_hours,
+    })
+    search_vpn_assignment.add_must([
+        TermMatch('tags', 'vpn'),
+        TermMatch('tags', 'netfilter'),
+        TermMatch('details.success', 'true'),
+        TermMatch('details.vpnip', source_ip),
+        PhraseMatch('summary', 'netfilter add upon connection'),
+    ])
+
+    assign_events = sorted(
+        [hit.get('_source', {}) for hit in search_fn(search_vpn_assignment)],
+        key=lambda evt: evt['details']['ts'],
+        reverse=True,  # Sort into descending order from most recent to least.
+    )
+
+    if len(assign_events) == 0:
+        return alert
+
+    event = assign_events[0]
+
+    details['vpnassignment'] = {
+        'username': event['details']['username'],
+        'originalip': event['details']['sourceipaddress'],
+    }
+
+    alert['details'] = details
+
+    return alert

--- a/alerts/plugins/vpn_assignment.py
+++ b/alerts/plugins/vpn_assignment.py
@@ -12,6 +12,7 @@ import netaddr
 from lib.config import ES
 from mozdef_util.elasticsearch_client import ElasticsearchClient
 from mozdef_util.query_models import SearchQuery, TermMatch, PhraseMatch
+from mozdef_util.utilities.toUTC import toUTC
 
 
 CONFIG_FILE = os.path.join(
@@ -115,7 +116,7 @@ def enrich(
 
     assign_events = sorted(
         [hit.get('_source', {}) for hit in search_fn(search_vpn_assignment)],
-        key=lambda evt: evt['details']['ts'],
+        key=lambda evt: toUTC(evt['details']['utctimestamp']),
         reverse=True,  # Sort into descending order from most recent to least.
     )
 

--- a/tests/alerts/plugins/test_vpn_assignment.py
+++ b/tests/alerts/plugins/test_vpn_assignment.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os
 import sys
 
@@ -36,8 +37,8 @@ class TestVPNAssignment:
             'hits': [
                 {
                     '_source': {
+                        'utctimestamp': datetime.utcnow(),
                         'details': {
-                            'ts': 1,
                             'username': 'tester@mozilla.com',
                             'sourceipaddress': '1.2.3.4',
                         }

--- a/tests/alerts/plugins/test_vpn_assignment.py
+++ b/tests/alerts/plugins/test_vpn_assignment.py
@@ -1,0 +1,103 @@
+import os
+import sys
+
+
+def mock_search_fn(results):
+    '''Creates a search function that returns a set of results on each call.
+    '''
+
+    def search_fn(_query):
+        return results['hits']
+
+    return search_fn
+
+
+class TestVPNAssignment:
+    def setup(self):
+        self.orig_path = os.getcwd()
+        self.alerts_path = os.path.join(
+            os.path.dirname(__file__),
+            '../../../alerts',
+        )
+
+        sys.path.insert(0, self.alerts_path)
+
+    def teardown(self):
+        os.chdir(self.orig_path)
+        sys.path.remove(self.alerts_path)
+
+        if 'lib' in sys.modules:
+            del sys.modules['lib']
+
+    def test_alert_enriched(self):
+        from alerts.plugins.vpn_assignment import enrich
+
+        assign_results = {
+            'hits': [
+                {
+                    '_source': {
+                        'details': {
+                            'ts': 1,
+                            'username': 'tester@mozilla.com',
+                            'sourceipaddress': '1.2.3.4',
+                        }
+                    }
+                }
+            ]
+        }
+
+        alert = {
+            'summary': 'test summary',
+            'details': {
+                'something': 'original',
+                'sourceipaddress': '10.48.123.13',
+            }
+        }
+
+        vpn_cidrs = [
+            '123.11.0.0/16',
+            '10.48.0.0/16',
+        ]
+
+        search_window_hours = 6
+
+        search_fn = mock_search_fn(assign_results)
+
+        enriched = enrich(alert, search_window_hours, vpn_cidrs, search_fn)
+
+        assert enriched['details']['something'] == 'original'
+        assert 'vpnassignment' in enriched['details']
+
+        assign = enriched['details']['vpnassignment']
+
+        assert assign.get('username') == 'tester@mozilla.com'
+        assert assign.get('originalip') == '1.2.3.4'
+
+    def test_not_vpn_ip(self):
+        from alerts.plugins.vpn_assignment import enrich
+
+        assign_results = {
+            'hits': [],
+        }
+
+        alert = {
+            'summary': 'test summary',
+            'details': {
+                'something': 'original',
+                'sourceipaddress': '10.48.123.13',
+            }
+        }
+
+        vpn_cidrs = [
+            '123.11.0.0/16',
+            # Here the IP address of the user the alert fired on is NOT in a VPN
+        ]
+
+        search_window_hours = 6
+
+        search_fn = mock_search_fn(assign_results)
+
+        enriched = enrich(alert, search_window_hours, vpn_cidrs, search_fn)
+
+        assert enriched['details']['something'] == 'original'
+        assert 'vpnassignment' not in enriched


### PR DESCRIPTION
This PR introduces a new alert plugin, `vpn_assignment`.  This plugin looks at the `sourceipaddress` of any alert and checks to see if it belongs to a VPN.  Upon finding an IP assignment, the plugin will augment the alert with information about the user to whom the IP within the VPN was assigned.  In particular, it creates a new data structure like

```json
"details": {
  "vpnassignment": {
    "username": "someperson@website.com",
    "originalip": "ip.outside.of.vpn",
  }
}
```

<img width="661" alt="Screen Shot 2020-06-09 at 4 06 09 PM" src="https://user-images.githubusercontent.com/682761/84195072-f9f49600-aa6b-11ea-92f0-53109a6da5ae.png">
