### PR TITLE
Alert when the Session Invalidation application is used to terminate a user's sessions

### DIFF
--- a/alerts/session_invalidation.py
+++ b/alerts/session_invalidation.py
@@ -62,6 +62,8 @@ class AlertSessionInvalidation(AlertTask):
         alert = self.createAlertDict(summary, category, tags, events)
 
         alert['details'].update({
+            'actor': actor,
+            'username': actor,
             'terminations': terminations,
         })
 

--- a/alerts/session_invalidation.py
+++ b/alerts/session_invalidation.py
@@ -46,6 +46,9 @@ class AlertSessionInvalidation(AlertTask):
             if event.get('details', {}).get('invalidateduser') is not None
         ]
 
+        if len(terminations) == 0:
+            return None
+
         affected_users = [
             t['invalidateduser']
             for t in terminations

--- a/alerts/session_invalidation.py
+++ b/alerts/session_invalidation.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+from lib.alerttask import AlertTask
+from mozdef_util.query_models import SearchQuery, TermMatch
+
+
+class AlertSessionInvalidation(AlertTask):
+    '''An alert that fires whenever the Session Invalidation application
+    is invoked to terminate a user's sessions.
+
+    See https://github.com/mozilla/session-invalidation/
+    '''
+
+    def main(self):
+        query = SearchQuery(minutes=15)
+
+        # Search for events from the session invalidation app wherein
+        # an authenticated user terminated a user's sessions.
+        query.add_must([
+            TermMatch('category', 'sessioninvalidation'),
+        ])
+
+        self.filtersManual(query)
+        self.searchEventsAggregated('details.actor', samplesLimit=2000)
+        self.walkAggregations(threshold=1, config=None)
+
+    def onAggregation(self, agg):
+        category = 'sessioninvalidation'
+        tags = ['sessioninvalidation']
+        severity = 'WARNING'
+
+        actor = agg['value']
+        events = agg['events']
+
+        terminations = [
+            {
+                'invalidateduser': event['details']['invalidateduser'],
+                'invalidatedsessions': event['details']['invalidatedsessions'],
+            }
+            for event in events
+            if event.get('details', {}).get('invalidateduser') is not None
+        ]
+
+        affected_users = [
+            t['invalidateduser']
+            for t in terminations
+        ]
+
+        summary = '{0} terminated sessions for user(s) {1}'.format(
+            actor,
+            ', '.join(affected_users),
+        )
+
+        alert = self.createAlertDict(summary, category, tags, events)
+
+        alert['details'].update({
+            'terminations': terminations,
+        })
+
+        return alert

--- a/tests/alerts/test_session_invalidation.py
+++ b/tests/alerts/test_session_invalidation.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+from tests.alerts.alert_test_suite import AlertTestSuite
+from tests.alerts.negative_alert_test_case import NegativeAlertTestCase
+from tests.alerts.positive_alert_test_case import PositiveAlertTestCase
+
+class TestAlertSessionInvalidation(AlertTestSuite):
+    alert_filename = 'session_invalidation'
+
+    default_event = {
+        '_source': {
+            'category': 'sessioninvalidation',
+            'details': {
+                'actor': 'actor@mozilla.com',
+                'invalidateduser': 'test@mozilla.com',
+                'invalidatedsessions': [
+                    'sso',
+                    'slack',
+                    'gsuite',
+                ],
+            },
+        },
+    }
+
+    no_invalidation_event = {
+        '_source': {
+            'category': 'sessioninvalidation',
+            'details': {
+                'actor': 'actor@mozilla.com',
+                'invalidateduser': None,
+                'invalidatedsessions': None,
+            },
+        },
+    }
+
+    default_alert = {
+        'category': 'sessioninvalidation',
+        'tags': ['sessioninvalidation'],
+        'severity': 'WARNING',
+        'details': {
+            'actor': 'actor@mozilla.com',
+            'username': 'actor@mozilla.com',
+            'terminations': [
+                {
+                    'invalidateduser': 'test@mozilla.com',
+                    'invalidatedsessions': [
+                        'sso',
+                        'slack',
+                        'gsuite',
+                    ],
+                },
+            ],
+        },
+    }
+
+    test_cases = [
+        PositiveAlertTestCase(
+            description='Alert fires when an actor terminates sessions',
+            events=[default_event],
+            expected_alert=default_alert,
+        ),
+        PositiveAlertTestCase(
+            description='Events wherein no termination happened not included',
+            events=[default_event, no_invalidation_event],
+            expected_alert=default_alert,
+        ),
+        NegativeAlertTestCase(
+            description='Alert does not fire when no terminations happened',
+            events=[no_invalidation_event],
+        ),
+    ]

--- a/tests/alerts/test_session_invalidation.py
+++ b/tests/alerts/test_session_invalidation.py
@@ -9,6 +9,7 @@ from tests.alerts.alert_test_suite import AlertTestSuite
 from tests.alerts.negative_alert_test_case import NegativeAlertTestCase
 from tests.alerts.positive_alert_test_case import PositiveAlertTestCase
 
+
 class TestAlertSessionInvalidation(AlertTestSuite):
     alert_filename = 'session_invalidation'
 


### PR DESCRIPTION
When the session invalidation application logs a message indicating that a user A has terminated sessions for user B, this alert fires with information about those users and their sessions.  In this case, there are duplicates because I ran my test a couple times with the same target user.

<img width="870" alt="Screen Shot 2020-06-23 at 4 33 49 PM" src="https://user-images.githubusercontent.com/682761/85462051-0f40e880-b573-11ea-91d1-f76282758c8b.png">
