### PR TITLE
Change Auth0 raw field from str repr to json

### DIFF
--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -9,6 +9,7 @@
 import hjson
 import sys
 import os
+import json
 import requests
 import traceback
 
@@ -354,7 +355,7 @@ def fetch_auth0_logs(config, headers, fromid):
 
         # Save raw initial message in final message
         # in case we ran into parsing errors
-        mozmsg.details["raw"] = str(msg)
+        mozmsg.details["raw_value"] = json.dumps(msg)
 
         mozmsg.send()
 


### PR DESCRIPTION
This will both change the Auth0 raw field to be called raw_value
and will change the representation from a Python repr to a JSON
encoded string. This will allow ElasticSearch to index this value
and make it searchable.

This is similar to what was done in #1586 and support #1607