### PR TITLE
Set an alert to acknowledged when the triage bot updates its status

### DIFF
--- a/tests/rest/test_rest_index.py
+++ b/tests/rest/test_rest_index.py
@@ -179,6 +179,8 @@ class TestAlertStatus(RestTestSuite):
         assert alert['status'] == 'acknowledged'
         assert alert['details']['triage']['user']['slack'] == 'tester'
         assert alert['details']['triage']['response'] == 'yes'
+        assert 'acknowledged' in alert
+        assert alert['acknowledgedby'] == 'triagebot'
 
         return
 


### PR DESCRIPTION
When the triage bot updates an alert's status to "acknowledged" in response to a user indicating that an alert was expected via Slack, we previously only updated the new "status" field.  This PR introduces a small change that results in the triage bot MQ plugin that reads user responses adding the "acknowledged" and "acknowledgedby" fields to the alert in MongoDB so that it will show up as "ack'd" in the MozDef UI.