### PR TITLE
Revert "Bump jquery from 3.4.0 to 3.5.0 in /meteor"

### DIFF
--- a/meteor/package-lock.json
+++ b/meteor/package-lock.json
@@ -224,9 +224,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
+      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
     },
     "jquery-ui": {
       "version": "1.12.1",

--- a/meteor/package.json
+++ b/meteor/package.json
@@ -11,7 +11,7 @@
     "@babel/runtime": "^7.1.2",
     "bcrypt": "^3.0.6",
     "dc": "^2.1.10",
-    "jquery": "^3.5.0",
+    "jquery": "^3.4.0",
     "jquery-ui": "^1.12.1",
     "meteor-node-stubs": "^0.4.1",
     "pivottable": "^2.22.0",


### PR DESCRIPTION
Reverts mozilla/MozDef#1620