### PR TITLE
EIS-2365

### DIFF
--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -168,7 +168,8 @@ def process_msg(mozmsg, msg):
         pass
 
     try:
-        details["username"] = msg.user_name
+        if msg.user_name:
+            details["username"] = msg.user_name
     except KeyError:
         pass
 
@@ -193,17 +194,20 @@ def process_msg(mozmsg, msg):
         pass
 
     try:
-        details["clientname"] = msg.client_name
+        if msg.client_name:
+            details["clientname"] = msg.client_name
     except KeyError:
         pass
 
     try:
-        details["connection"] = msg.connection
+        if msg.connection:
+            details["connection"] = msg.connection
     except KeyError:
         pass
 
     try:
-        details["clientid"] = msg.client_id
+        if msg.client_id:
+            details["clientid"] = msg.client_id
     except KeyError:
         pass
 
@@ -241,22 +245,24 @@ def process_msg(mozmsg, msg):
             # Update a rule, add a site, update a site, etc
             details["description"] = msg.description
     except KeyError:
-        details["description"] = ""
+        pass
 
     # set the summary
     # make summary be action/username (success login user@place.com)
     # if no details.username field exists we don't add it.
-    if 'username' in details and 'clientname' in details:
-        mozmsg.summary = "{event} {username} to {clientname}".format(event=details.eventname, username=details.username.strip(), clientname=details.clientname)
 
-    # Build summary as action and description and email (if it exists)
-    # if details.email doesn't exist, we do not add it.
-    elif 'email' in details:
-        mozmsg.summary = "{event}: {desc} for account: {email}".format(event=details.eventname, desc=details.description, email=details.email)
+    # Build summary if neither email, description, nor username exists
+    if 'eventname' in details:
+        mozmsg.summary = "{event}".format(event=details.eventname)
+        if 'description' in details and details['description'] != "None":
+            mozmsg.summary += " {description}".format(event=details.eventname, description=details.description)
+        if 'username' in details and details['username'] != "None":
+            mozmsg.summary += " by {username}".format(username=details.username)
+        if 'email' in details and details['email'] != "None":
+            mozmsg.summary += " account: {email}".format(email=details.email)
+        if 'clientname' in details and details['clientname'] != "None":
+            mozmsg.summary += " to: {clientname}".format(clientname=details.clientname)
 
-    # Build summary if neither email nor username exists
-    elif 'email' not in details and 'username' not in details:
-        mozmsg.summary = "{event}: {desc} : user/account UNKNOWN".format(event=details.eventname, desc=details.description)
     # Get user data if present in response body
     try:
         if "multifactor" in msg.details.response.body and type(msg.details.response.body.multifactor) is list:

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -193,6 +193,21 @@ def process_msg(mozmsg, msg):
         pass
 
     try:
+        details["clientname"] = msg.client_name
+    except KeyError:
+        pass
+
+    try:
+        details["connection"] = msg.connection
+    except KeyError:
+        pass
+
+    try:
+        details["clientid"] = msg.client_id
+    except KeyError:
+        pass
+
+    try:
         # auth0 calls these events with an acronym and name
         details["eventname"] = log_types[msg.type].event
         # determine the event category
@@ -231,8 +246,8 @@ def process_msg(mozmsg, msg):
     # set the summary
     # make summary be action/username (success login user@place.com)
     # if no details.username field exists we don't add it.
-    if 'username' in details:
-        mozmsg.summary = "{event} {username}".format(event=details.eventname, username=details.username.strip())
+    if 'username' in details and 'clientname' in details:
+        mozmsg.summary = "{event} {username} to {clientname}".format(event=details.eventname, username=details.username.strip(), clientname=details.clientname)
 
     # Build summary as action and description and email (if it exists)
     # if details.email doesn't exist, we do not add it.
@@ -264,21 +279,6 @@ def process_msg(mozmsg, msg):
     try:
         if "last_login" in msg.details.response.body and msg.details.response.body.last_login is not None:
             details.user_last_login = msg.details.response.body.last_login
-    except KeyError:
-        pass
-
-    try:
-        details["clientname"] = msg.client_name
-    except KeyError:
-        pass
-
-    try:
-        details["connection"] = msg.connection
-    except KeyError:
-        pass
-
-    try:
-        details["clientid"] = msg.client_id
     except KeyError:
         pass
 

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -401,7 +401,7 @@ def fetch_auth0_logs(config, headers, fromid):
 
         # Save raw initial message in final message
         # in case we ran into parsing errors
-        mozmsg.details["raw_value"] = json.dumps(msg)
+        mozmsg.details["raw_value"] = [msg]
 
         mozmsg.send()
 

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -241,28 +241,47 @@ def process_msg(mozmsg, msg):
         mozmsg.summary = "{event} {username}".format(event=details.eventname, username=tmp_username)
     else:
         # default summary as action and description (if it exists)
+        tmp_email = "UNKNOWN"
         if 'email' in details:
             tmp_email = details.email
-        mozmsg.summary = "{event} {desc}".format(event=details.eventname, desc=details.description, email=tmp_email)
+        mozmsg.summary = "{event} {desc} {email}".format(event=details.eventname, desc=details.description, email=tmp_email)
 
     # Get user data if present in response body
     try:
-        if "last_ip" in msg.response.body.identities and msg.response.body.identities.last_ip is not None:
-            details.last_known_user_ip = msg.response.body.identities.last_ip
+        if "identities" in msg.details.response.body and type(msg.details.response.body.identities) is list:
+            details.identities = msg.details.response.body.identities
     except KeyError:
-        details.last_known_user_ip = ""
-    
-    try:
-        if "last_login" in msg.response.body.identities and msg.response.body.identities.last_login is not None:
-            details.last_user_login = msg.response.body.identities.last_login
-    except KeyError:
-        details.last_user_login = ""
+        pass
 
     try:
-        if "multifactor" in msg.response.body and msg.response.body.multifactor is not None:
-            details.mfa_provider = msg.response.body.multifactor
+        if "multifactor" in msg.details.response.body and type(msg.details.response.body.multifactor) is list:
+            details.mfa_provider = msg.details.response.body.multifactor
     except KeyError:
-        details.mfa_provider = []
+        pass
+
+    try:
+        if "_HRData" in msg.details.response.body and type(msg.details.response.body._HRData) is dict:
+            details.user_metadata = [msg.details.response.body._HRData]
+    except KeyError:
+        pass
+
+    try:
+        if "ldap_groups" in msg.details.response.body and type(msg.details.response.body.ldap_groups) is list:
+            details.ldap_groups = msg.details.response.body.ldap_groups
+    except KeyError:
+        pass
+
+    try:
+        if "last_ip" in msg.details.response.body and msg.details.response.body.last_ip is not None:
+            details.user_last_known_ip = msg.details.response.body.last_ip
+    except KeyError:
+        pass
+
+    try:
+        if "last_login" in msg.details.response.body and msg.details.response.body.last_login is not None:
+            details.user_last_login = msg.details.response.body.last_login
+    except KeyError:
+        pass
 
     try:
         details["clientname"] = msg.client_name

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -235,16 +235,16 @@ def process_msg(mozmsg, msg):
     # make summary be action/username (success login user@place.com)
     # include UNKNOWN as username value in summary
     # if no details.username field exists
-    tmp_username = "UNKNOWN"
     if 'username' in details:
-        tmp_username = details.username
-        mozmsg.summary = "{event} {username}".format(event=details.eventname, username=tmp_username)
+        mozmsg.summary = "{event} {username}".format(event=details.eventname, username=details.username)
 
-    # default summary as action and description (if it exists)
-    tmp_email = "UNKNOWN"
-    if 'email' in details:
-        tmp_email = details.email
-        mozmsg.summary = "{event} {desc} {email}".format(event=details.eventname, desc=details.description, email=tmp_email)
+    # Build summary as action and description and email (if it exists)
+    elif 'email' in details:
+        mozmsg.summary = "{event} {desc} {email}".format(event=details.eventname, desc=details.description, email=details.email)
+
+    # Build summary if neither email nor username exists
+    elif 'email' not in details and 'username' not in details:
+        mozmsg.summary = "{event} {desc}".format(event=details.eventname, desc=details.description)
 
     # Get user data if present in response body
     try:

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -250,20 +250,8 @@ def process_msg(mozmsg, msg):
 
     # Get user data if present in response body
     try:
-        if "identities" in msg.details.response.body and type(msg.details.response.body.identities) is list:
-            details.identities = msg.details.response.body.identities
-    except KeyError:
-        pass
-
-    try:
         if "multifactor" in msg.details.response.body and type(msg.details.response.body.multifactor) is list:
             details.mfa_provider = msg.details.response.body.multifactor
-    except KeyError:
-        pass
-
-    try:
-        if "_HRData" in msg.details.response.body and type(msg.details.response.body._HRData) is dict:
-            details.user_metadata = [msg.details.response.body._HRData]
     except KeyError:
         pass
 

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -178,7 +178,6 @@ def process_msg(mozmsg, msg):
         # the details.request/response exist for api calls
         # but not for logins and other events
         # check and prefer them if present.
-        details["username"] = msg.details.request.auth.user.name
         if type(msg.details.response.body) is not list:
             details["action"] = msg.details.response.body.name
     except KeyError:
@@ -235,17 +234,16 @@ def process_msg(mozmsg, msg):
     # make summary be action/username (success login user@place.com)
     # if no details.username field exists we don't add it.
     if 'username' in details:
-        mozmsg.summary = "{event} {username}".format(event=details.eventname, username=details.username)
+        mozmsg.summary = "{event} {username}".format(event=details.eventname, username=details.username.strip())
 
     # Build summary as action and description and email (if it exists)
     # if details.email doesn't exist, we do not add it.
     elif 'email' in details:
-        mozmsg.summary = "{event} {desc} {email}".format(event=details.eventname, desc=details.description, email=details.email)
+        mozmsg.summary = "{event}: {desc} for account: {email}".format(event=details.eventname, desc=details.description, email=details.email)
 
     # Build summary if neither email nor username exists
     elif 'email' not in details and 'username' not in details:
-        mozmsg.summary = "{event} {desc}".format(event=details.eventname, desc=details.description)
-
+        mozmsg.summary = "{event}: {desc} : user/account UNKNOWN".format(event=details.eventname, desc=details.description)
     # Get user data if present in response body
     try:
         if "multifactor" in msg.details.response.body and type(msg.details.response.body.multifactor) is list:

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -105,7 +105,7 @@ log_types = DotDict(
         "limit_wc": {"event": "Blocked Account", "level": 4},
         "pwd_leak": {"event": "User attempted to login with a leaked password", "level": 4},
         "s": {"event": "Success Login", "level": 1},
-        "sapi": {"event": "API Operation", "level": 1},
+        "sapi": {"event": "Success API Operation", "level": 1},
         "sce": {"event": "Success Change Email", "level": 1},
         "scoa": {"event": "Success cross-origin authentication", "level": 1},
         "scp": {"event": "Success Change Password", "level": 1},
@@ -233,19 +233,18 @@ def process_msg(mozmsg, msg):
         details["description"] = ""
 
     # set the summary
-    if "auth" in mozmsg._category:
-        # make summary be action/username (success login user@place.com)
-        # include UNKNOWN as username value in summary
-        # if no details.username field exists
-        tmp_username = "UNKNOWN"
-        if 'username' in details:
-            tmp_username = details.username
+    # make summary be action/username (success login user@place.com)
+    # include UNKNOWN as username value in summary
+    # if no details.username field exists
+    tmp_username = "UNKNOWN"
+    if 'username' in details:
+        tmp_username = details.username
         mozmsg.summary = "{event} {username}".format(event=details.eventname, username=tmp_username)
-    else:
-        # default summary as action and description (if it exists)
-        tmp_email = "UNKNOWN"
-        if 'email' in details:
-            tmp_email = details.email
+
+    # default summary as action and description (if it exists)
+    tmp_email = "UNKNOWN"
+    if 'email' in details:
+        tmp_email = details.email
         mozmsg.summary = "{event} {desc} {email}".format(event=details.eventname, desc=details.description, email=tmp_email)
 
     # Get user data if present in response body

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -9,7 +9,6 @@
 import hjson
 import sys
 import os
-import json
 import requests
 import traceback
 

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -233,12 +233,12 @@ def process_msg(mozmsg, msg):
 
     # set the summary
     # make summary be action/username (success login user@place.com)
-    # include UNKNOWN as username value in summary
-    # if no details.username field exists
+    # if no details.username field exists we don't add it.
     if 'username' in details:
         mozmsg.summary = "{event} {username}".format(event=details.eventname, username=details.username)
 
     # Build summary as action and description and email (if it exists)
+    # if details.email doesn't exist, we do not add it.
     elif 'email' in details:
         mozmsg.summary = "{event} {desc} {email}".format(event=details.eventname, desc=details.description, email=details.email)
 

--- a/cron/auth02mozdef.py
+++ b/cron/auth02mozdef.py
@@ -157,8 +157,6 @@ def process_msg(mozmsg, msg):
     success_words = ["Success"]
     failed_words = ["Failed"]
 
-    # Set source to Auth0
-    mozmsg.source = "auth0"
     # fields that should always exist
     mozmsg.timestamp = msg.date
     details["messageid"] = msg._id
@@ -371,6 +369,8 @@ def fetch_auth0_logs(config, headers, fromid):
             mozmsg.set_send_to_syslog(True, only_syslog=True)
         mozmsg.hostname = config.auth0.url
         mozmsg.tags = ["auth0"]
+        # Because MozDef_Client doesn't support source, this will always be UNKNOWN as of 7/2020
+        mozmsg.source = "auth0"
         msg = byteify(msg)
         msg = DotDict(msg)
         lastid = msg._id

--- a/tests/cron/test_auth02mozdef.py
+++ b/tests/cron/test_auth02mozdef.py
@@ -39,7 +39,7 @@ class TestAuth0Messages():
         process_msg(mozmsg, self.sample_event)
         assert mozmsg.details.username == 'ttesterson@mozilla.com'
         assert mozmsg.details.userid == 'ad|Test-Connection|ttesterson'
-        assert mozmsg.summary == 'Success Silent Auth by ttesterson@mozilla.com'
+        assert mozmsg.summary == 'Success Silent Auth by ttesterson@mozilla.com to: example.mozilla.org'
 
     def test_sample_event_username_nonexistent(self):
         mozmsg = mozdef.MozDefEvent('http://localhost:9090')

--- a/tests/cron/test_auth02mozdef.py
+++ b/tests/cron/test_auth02mozdef.py
@@ -39,7 +39,7 @@ class TestAuth0Messages():
         process_msg(mozmsg, self.sample_event)
         assert mozmsg.details.username == 'ttesterson@mozilla.com'
         assert mozmsg.details.userid == 'ad|Test-Connection|ttesterson'
-        assert mozmsg.summary == 'Success Silent Auth ttesterson@mozilla.com'
+        assert mozmsg.summary == 'Success Silent Auth by ttesterson@mozilla.com'
 
     def test_sample_event_username_nonexistent(self):
         mozmsg = mozdef.MozDefEvent('http://localhost:9090')


### PR DESCRIPTION
Still a WIP

- Adds user email to administrative events that affect a user.
- Adds mfa_provider to details
- Adds user_last_ip
- Adds user_last_login
- Adds ldap_groups as a searchable object
- Adds msg as raw_value and a searchable object
- Adds success to successful API operations
- Makes summaries more informative
- removes json import, no longer needed
- Adds RP's to Summary