### PR TITLE
adding new triagebot escalation alert

### DIFF
--- a/alerts/triagebot_escalation.conf
+++ b/alerts/triagebot_escalation.conf
@@ -1,0 +1,3 @@
+[options]
+url = https://www.mozilla.org
+severity = INFO

--- a/alerts/triagebot_escalation.py
+++ b/alerts/triagebot_escalation.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+from lib.alerttask import AlertTask
+from mozdef_util.query_models import SearchQuery, TermMatch, ExistsMatch
+
+
+class AlertTriageBotEscalation(AlertTask):
+    def main(self):
+        self.parse_config('triagebot_escalation.conf', ['url', 'severity'])
+
+        search_query = SearchQuery(minutes=15)
+
+        search_query.add_must([
+            TermMatch('category', 'triagebot'),
+            TermMatch('details.userresponse', 'no'),
+            ExistsMatch('details.email'),
+            ExistsMatch('details.identifier')
+        ])
+
+        self.filtersManual(search_query)
+
+        # Search events
+        self.searchEventsSimple()
+        self.walkEvents()
+
+    # Set alert properties
+    def onEvent(self, event):
+        msg = event['_source']
+        category = 'access'
+        tags = ['ssh_critical_host_login_escalation', 'pagerduty', 'triagebot']
+        severity = self.config.severity
+        url = self.config.url
+
+        # the summary of the alert is the same as the event
+        summary = "TriageBot Escalation for event: {0} sent to PagerDuty per 'NO' response from User: {1}".format(msg['details']['identifier'], msg['details']['email'])
+
+        # Create the alert object based on these properties
+        return self.createAlertDict(summary, category, tags, [event], severity, url)

--- a/mq/plugins/triage_bot.py
+++ b/mq/plugins/triage_bot.py
@@ -207,9 +207,11 @@ def process(msg, meta, api_cfg):
     # in particular is reserved, so we will expand ours' contents out.
     del msg["details"]["user"]
     del msg["details"]["response"]
+    msg["category"] = "triagebot"
     msg["details"]["email"] = email
     msg["details"]["slack"] = slack
     msg["details"]["userresponse"] = resp.value
+    msg["summary"] = "TriageBot Response: {0} from: {1}".format(resp.value, email)
 
     return (msg, meta)
 

--- a/tests/alerts/test_triagebot_escalation.py
+++ b/tests/alerts/test_triagebot_escalation.py
@@ -33,7 +33,7 @@ class TestAlertTriageBotEscalation(AlertTestSuite):
     # This alert is the expected result from running this task
     default_alert = {
         "category": "access",
-        "severity": "CRITICAL",
+        "severity": "INFO",
         "summary": "TriageBot Escalation for event: UdEkkIEJFXEy54grVnfy sent to PagerDuty per 'NO' response from User: test@testerson.com",
         "tags": ['ssh_critical_host_login_escalation', 'pagerduty', 'triagebot'],
     }

--- a/tests/alerts/test_triagebot_escalation.py
+++ b/tests/alerts/test_triagebot_escalation.py
@@ -1,0 +1,88 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# Copyright (c) 2017 Mozilla Corporation
+
+from .positive_alert_test_case import PositiveAlertTestCase
+from .negative_alert_test_case import NegativeAlertTestCase
+
+from .alert_test_suite import AlertTestSuite
+
+
+class TestAlertTriageBotEscalation(AlertTestSuite):
+    alert_filename = "triagebot_escalation"
+    alert_classname = 'AlertTriageBotEscalation'
+
+    # This event is the default positive event that will cause the
+    # alert to trigger
+    default_event = {
+        "_source": {
+            "hostname": "UNKNOWN",
+            "details": {
+                "identifier": "UdEkkIEJFXEy54grVnfy",
+                "identityConfidence": "low",
+                "email": "test@testerson.com",
+                "slack": "U4J8Z3DJT",
+                "userresponse": "no"
+            },
+            "category": "triagebot",
+            "summary": "TriageBot Response: no from: test@testerson.com"
+        }
+    }
+
+    # This alert is the expected result from running this task
+    default_alert = {
+        "category": "access",
+        "severity": "CRITICAL",
+        "summary": "TriageBot Escalation for event: UdEkkIEJFXEy54grVnfy sent to PagerDuty per 'NO' response from User: test@testerson.com",
+        "tags": ['ssh_critical_host_login_escalation', 'pagerduty', 'triagebot'],
+    }
+
+    test_cases = []
+
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test with default event and default alert expected",
+            events=AlertTestSuite.create_events(default_event, 1),
+            expected_alert=default_alert
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['identifier'] = 'AbDpsIOPERXEy54grVnfy'
+    alert = AlertTestSuite.create_alert(default_alert)
+    alert['summary'] = "TriageBot Escalation for event: AbDpsIOPERXEy54grVnfy sent to PagerDuty per 'NO' response from User: test@testerson.com"
+    test_cases.append(
+        PositiveAlertTestCase(
+            description="Positive test with different event_id in the summary",
+            events=[event],
+            expected_alert=alert
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['userresponse'] = 'yes'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test with events with a user response of 'yes'",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['details']['email'] = None
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case email key excluded",
+            events=[event],
+        )
+    )
+
+    event = AlertTestSuite.create_event(default_event)
+    event['_source']['category'] = 'bad'
+    test_cases.append(
+        NegativeAlertTestCase(
+            description="Negative test case with bad category key",
+            events=[event],
+        )
+    )

--- a/tests/mq/plugins/test_triage_bot.py
+++ b/tests/mq/plugins/test_triage_bot.py
@@ -102,6 +102,8 @@ class TestTriageBot:
             (new_msg, new_meta) = bot.process(msg, {}, cfg)
 
             assert "user" not in msg["details"]
+            assert msg["category"] == "triagebot"
+            assert msg["summary"] == "TriageBot Response: yes from: tester@site.com"
             assert msg["details"] == {
                 "identifier": "id",
                 "email": "tester@site.com",


### PR DESCRIPTION
- Adds a summary to the triagebot events that get sent when a user responds to a slack prompt.
- Adds an alert that will trigger a Pagerduty event in the event a user responds to the negative.
- Adds unit testing for this alert to ensure it functions as intended
- Setting the severity to INFO until we monitor it in production and decide it's good to set to CRITICAL