### PR TITLE
Deprecate old plugins field

### DIFF
--- a/mozdef_util/HISTORY.rst
+++ b/mozdef_util/HISTORY.rst
@@ -119,3 +119,11 @@ Add is_ip utility function
 ------------------
 
 * Ensure dict2List changes are included
+
+3.0.7 (2020-08-03)
+------------------
+
+* Replaces plugin structure in event with mozdef data class structure
+* Updates wheel version in requirements.txt
+* Adds comments to Make file
+* Updates Readme with release instructions

--- a/mozdef_util/Makefile
+++ b/mozdef_util/Makefile
@@ -15,6 +15,8 @@ export PRINT_HELP_PYSCRIPT
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
+# CLEAN TARGETS
+
 clean: clean-build clean-pyc ## remove all build and Python artifacts
 
 clean-build: ## remove build artifacts
@@ -30,8 +32,12 @@ clean-pyc: ## remove Python file artifacts
 	find . -name '*~' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -fr {} +
 
+# LINT TARGET
+
 lint: ## check style with flake8
 	flake8 mozdef_util
+
+# RELEASE TARGETS
 
 release: dist ## package and upload a release
 	twine upload dist/*
@@ -40,6 +46,8 @@ dist: clean ## builds source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist
+
+# INSTALL TARGET
 
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install

--- a/mozdef_util/README.rst
+++ b/mozdef_util/README.rst
@@ -6,4 +6,25 @@ MozDef Util
 Utilities shared throughout the MozDef codebase
 
 
-* Documentation: https://mozdef.readthedocs.io/en/latest/mozdef_util.html
+* Usage Documentation: https://mozdef.readthedocs.io/en/latest/mozdef_util.html
+
+Before a New release
+--------------------
+
+#. Run *make clean* to remove any previous build data
+#. Modify the version in the setup.py file.
+#. Add the new version and list the changes in the HISTORY.md file
+
+To Push a New Release
+---------------------
+
+This package contains a Makefile that will allow you to run the following commands:
+
+#. If you haven't run *make clean* yet, do that before you run make release.
+#. Run *make release* which will package and upload the release.
+
+Additional options provided by the Makefile:
+
+#. *make dist* builds source and wheel package
+#. *make install* installs the package to the active Python's site-packages
+#. *make lint* runs flake8 on the codebase

--- a/mozdef_util/requirements_dev.txt
+++ b/mozdef_util/requirements_dev.txt
@@ -1,6 +1,6 @@
 pip==18.1
 bumpversion==0.5.3
-wheel==0.32.1
+wheel==0.34.2
 watchdog==0.9.0
 flake8==3.5.0
 tox==3.5.2

--- a/mozdef_util/setup.py
+++ b/mozdef_util/setup.py
@@ -58,6 +58,6 @@ setup(
     test_suite='tests',
     tests_require=[],
     url='https://github.com/mozilla/MozDef/tree/master/lib',
-    version='3.0.6',
+    version='3.0.7',
     zip_safe=False,
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ ipwhois==0.15.0
 jmespath==0.9.3
 kombu==4.1.0
 mozdef-client==1.0.11
-mozdef-util==3.0.6
+mozdef-util==3.0.7
 netaddr==0.7.19
 oauth2client==1.4.12
 pyOpenSSL==18.0.0

--- a/tests/alerts/actions/test_triage_bot.py
+++ b/tests/alerts/actions/test_triage_bot.py
@@ -42,7 +42,11 @@ def _ssh_sensitive_host_alert():
                         "timestamp": "2019-11-04T23:03:17+00:00",
                         "category": "syslog",
                         "type": "event",
-                        "plugins": ["parse_sshd", "parse_su", "sshdFindIP"],
+                        "mozdef": {
+                            "plugins": [
+                                "parse_sshd", "parse_su", "sshdFindIP"
+                            ]
+                        },
                     },
                     "documentid": "X8-tOG4B-YuPuGRRXQta",
                 }
@@ -110,7 +114,9 @@ def _duo_bypass_code_gen_alert():
                         "utctimestamp": "2019-11-04T23:31:32+00:00",
                         "timestamp": "2019-11-04T23:31:32+00:00",
                         "type": "event",
-                        "plugins": [],
+                        "mozdef": {
+                            "plugins": []
+                        },
                         "source": "UNKNOWN",
                     },
                     "documentid": "wPPKOG4B-YuPuGRRc2s7",
@@ -179,7 +185,9 @@ def _duo_bypass_code_used_alert():
                         "utctimestamp": "2019-10-21T15:48:43+00:00",
                         "timestamp": "2019-10-21T15:48:43+00:00",
                         "type": "event",
-                        "plugins": [],
+                        "mozdef": {
+                            "plugins": []
+                        },
                         "source": "UNKNOWN",
                         "alerts": [
                             {"index": "alerts-201910", "id": "J8b2dR63-kMa62bd-92E"}
@@ -255,13 +263,15 @@ def _ssh_access_releng_alert():
                         "severity": "INFO",
                         "category": "syslog",
                         "type": "event",
-                        "plugins": [
-                            "parse_sshd",
-                            "parse_su",
-                            "sshdFindIP",
-                            "ipFixup",
-                            "geoip",
-                        ],
+                        "mozdef": {
+                            "plugins": [
+                                "parse_sshd",
+                                "parse_su",
+                                "sshdFindIP",
+                                "ipFixup",
+                                "geoip",
+                            ]
+                        },
                         "processid": "UNKNOWN",
                         "processname": "UNKNOWN",
                         "source": "UNKNOWN",

--- a/tests/mozdef_util/utilities/test_dict2List.py
+++ b/tests/mozdef_util/utilities/test_dict2List.py
@@ -85,7 +85,11 @@ TEST_ALERT = {
                 "utctimestamp": "2020-04-22T21:31:35.274785+00:00",
                 "timestamp": "2020-04-22T21:31:35.274785+00:00",
                 "type": "event",
-                "plugins": ["ipFixup", "geoip"],
+                "mozdef": {
+                    "plugins": [
+                        "ipFixup", "geoip"
+                    ]
+                },
                 "source": "UNKNOWN",
             },
             "documentid": "JN7No3EBh9xp2NOIpD4Q",
@@ -134,7 +138,11 @@ TEST_ALERT = {
                 "utctimestamp": "2020-04-22T21:31:35.564107+00:00",
                 "timestamp": "2020-04-22T21:31:35.564107+00:00",
                 "type": "event",
-                "plugins": ["ipFixup", "geoip"],
+                "mozdef": {
+                    "plugins": [
+                        "ipFixup", "geoip"
+                    ]
+                },
                 "source": "UNKNOWN",
             },
             "documentid": "Jd7No3EBh9xp2NOIpT40",
@@ -183,7 +191,11 @@ TEST_ALERT = {
                 "utctimestamp": "2020-04-22T21:31:35.852684+00:00",
                 "timestamp": "2020-04-22T21:31:35.852684+00:00",
                 "type": "event",
-                "plugins": ["ipFixup", "geoip"],
+                "mozdef": {
+                    "plugins": [
+                        "ipFixup", "geoip"
+                    ]
+                },
                 "source": "UNKNOWN",
             },
             "documentid": "Jt7No3EBh9xp2NOIpj5T",
@@ -232,7 +244,11 @@ TEST_ALERT = {
                 "utctimestamp": "2020-04-22T21:31:36.427461+00:00",
                 "timestamp": "2020-04-22T21:31:36.427461+00:00",
                 "type": "event",
-                "plugins": ["ipFixup", "geoip"],
+                "mozdef": {
+                    "plugins": [
+                        "ipFixup", "geoip"
+                    ]
+                },
                 "source": "UNKNOWN",
             },
             "documentid": "KN7No3EBh9xp2NOIqD6R",
@@ -281,7 +297,11 @@ TEST_ALERT = {
                 "utctimestamp": "2020-04-22T21:31:36.713494+00:00",
                 "timestamp": "2020-04-22T21:31:36.713494+00:00",
                 "type": "event",
-                "plugins": ["ipFixup", "geoip"],
+                "mozdef": {
+                    "plugins": [
+                        "ipFixup", "geoip"
+                    ]
+                },
                 "source": "UNKNOWN",
             },
             "documentid": "Kd7No3EBh9xp2NOIqT6x",
@@ -352,7 +372,11 @@ TEST_ALERT = {
                 "utctimestamp": "2020-04-22T21:36:01.405116+00:00",
                 "timestamp": "2020-04-22T21:36:01.405116+00:00",
                 "type": "event",
-                "plugins": ["ipFixup", "geoip"],
+                "mozdef": {
+                    "plugins": [
+                        "ipFixup", "geoip"
+                    ]
+                },
                 "source": "UNKNOWN",
             },
             "documentid": "497Ro3EBh9xp2NOIs0Sk",
@@ -401,7 +425,11 @@ TEST_ALERT = {
                 "utctimestamp": "2020-04-22T21:36:01.689772+00:00",
                 "timestamp": "2020-04-22T21:36:01.689772+00:00",
                 "type": "event",
-                "plugins": ["ipFixup", "geoip"],
+                "mozdef": {
+                    "plugins": [
+                        "ipFixup", "geoip"
+                    ]
+                },
                 "source": "UNKNOWN",
             },
             "documentid": "Jd7Ro3EBh9xp2NOItEXH",


### PR DESCRIPTION
To remove the leftover plugins: artifact we must update the mozdef_util pypi package.
This PR is to ensure that update gets captured and also allows for review of the update.