### PR TITLE
Join regular testing commands for predictability in Alert Guide

### DIFF
--- a/docs/source/alert_development_guide.rst
+++ b/docs/source/alert_development_guide.rst
@@ -36,8 +36,7 @@ This test should pass and you will have confirmed you have a working environment
 
 At this point, begin development and periodically run your unit-tests locally with the following commands::
 
-  make build-tests
-  make run-tests TEST_CASE=tests/alerts/[YOUR ALERT TEST FILE].py
+  make build-tests && make run-tests TEST_CASE=tests/alerts/[YOUR ALERT TEST FILE].py
 
 
 Background on concepts


### PR DESCRIPTION
I ran into some issues with testing alerts where I was runnning the make test command without rebuilding and it caused me to waste some time, making this change hoping that it will prevent others from falling in that hole.