### PR TITLE
docs: fix simple typo, somehwere -> somewhere

### DIFF
--- a/docs/source/geomodel/specifications/v0_1.rst
+++ b/docs/source/geomodel/specifications/v0_1.rst
@@ -275,7 +275,7 @@ in another that an alert will be emitted by GeoModel.
 Realistic Travel Excluded
 -------------------------
 
-As an investigator, I expect that if someone starts working somehwere, gets
+As an investigator, I expect that if someone starts working somewhere, gets
 on a plane and continues working after arriving in their destination that an
 alert will **not** be emitted by GeoModel.
 


### PR DESCRIPTION
There is a small typo in docs/source/geomodel/specifications/v0_1.rst.

Should read `somewhere` rather than `somehwere`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md